### PR TITLE
Change tags on label images.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'pandas',
         'python-magic',
         'pyvips',
-        'tifftools>=1.0.0.dev42',
+        'tifftools>=1.0.0.dev46',
         'xlrd',
     ],
     license='Apache Software License 2.0',


### PR DESCRIPTION
This should allow the output images to work with Aperio's ImageScope.

This also always generates square label images.

Closes #115.