### PR TITLE
Reduce the error messages that can be shown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changes
+- Changed the case of the default deployed collection name (#146)
+- Don't percolate server error messages to client error messages (#147)
+
 ## Version 1.2.7
 
 ### Changes

--- a/wsi_deid/web_client/views/HierarchyWidget.js
+++ b/wsi_deid/web_client/views/HierarchyWidget.js
@@ -82,9 +82,11 @@ function performAction(action) {
         }
     }).fail((resp) => {
         let text = actions[action].fail;
+        /*
         if (resp.responseJSON && resp.responseJSON.message) {
             text += ' ' + resp.responseJSON.message;
         }
+        */
         events.trigger('g:alert', {
             icon: 'cancel',
             text: text,


### PR DESCRIPTION
Don't add server error messages to the end of the client error message.