### PR TITLE
Various fixes based on feedback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 
-## Unreleased
+## Version 1.3.1
+
+### Changes
+- The schema now restricts Proc_ID to 01-99 and Slide_ID to 01-20
+- Blank lines are now allowed in DeID Upload files.
+- Files starting with ~$ are ignored during import
+
+### Bug Fixes
+- The Export Jobs Folder wasn't being created
 
 ## Version 1.3.0
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -29,6 +29,14 @@ csv5 = """Some,unimportant,row
 TokenID,Proc_Seq,Proc_Type,Spec_Site,Slide_ID,ImageID,InputFileName
 0579XY112001,01,Biopsy,C717-Brain stem,01,0579XY112001_01_01,01-A.svs"""
 
+csv6 = """TokenID,Proc_Seq,Proc_Type,Spec_Site,Slide_ID,ImageID,InputFileName
+0579XY112001,00,Biopsy,C717-Brain stem,00,0579XY112001_00_00,01-A.svs
+0579XY112001,01,Biopsy,C717-Brain stem,01,0579XY112001_01_01,01-A.svs
+0579XY112001,02,Biopsy,C717-Brain stem,20,0579XY112001_02_20,01-A.svs
+0579XY112001,98,Biopsy,C717-Brain stem,21,0579XY112001_98_21,01-A.svs
+0579XY112001,99,Biopsy,C717-Brain stem,30,0579XY112001_99_30,01-A.svs"""
+
+
 
 @pytest.mark.parametrize('csv,errorlist', (
     (csv2, [None]),
@@ -45,6 +53,13 @@ TokenID,Proc_Seq,Proc_Type,Spec_Site,Slide_ID,ImageID,InputFileName
     (csv3, [["Invalid row 2 ('Spec_Site' is a required property)"]]),
     (csv4, [["Invalid row 2 (Additional properties are not allowed ('Extra' was unexpected))"]]),
     (csv5, [None]),
+    (csv6, [
+        ['Invalid Proc_Seq in B2', 'Invalid Slide_ID in E2'],
+        None,
+        None,
+        ['Invalid Slide_ID in E5'],
+        ['Invalid Slide_ID in E6'],
+    ]),
 ))
 def test_schema(tmp_path, csv, errorlist):
     validator = getSchemaValidator()

--- a/wsi_deid/schema/importManifestSchema.json
+++ b/wsi_deid/schema/importManifestSchema.json
@@ -38,7 +38,7 @@
     },
     "Proc_Seq": {
       "$id": "#/properties/Proc_Seq",
-      "pattern": "^[0-9]{2}$",
+      "pattern": "^(?!00)[0-9]{2}$",
       "title": "Proc_Seq",
       "description": "Sequence number of the procedure for the subject when available reports are in chronological order.",
       "default": "",
@@ -403,7 +403,7 @@
     },
     "Slide_ID": {
       "$id": "#/properties/Slide_ID",
-      "pattern": "^[0-9]{2}$",
+      "pattern": "^((?!00)[0-1][0-9]|20)$",
       "title": "Slide_ID",
       "description": "Indicates the sequence of the slides for a given subject across all specimens.",
       "default": "",

--- a/wsi_deid/web_client/views/HierarchyWidget.js
+++ b/wsi_deid/web_client/views/HierarchyWidget.js
@@ -21,7 +21,7 @@ function performAction(action) {
         let text = actions[action].done;
         let any = false;
         if (resp.action === 'ingest') {
-            if (['duplicate', 'missing', 'unlisted', 'failed', 'notexcel', 'badentry'].some((key) => resp[key])) {
+            if (['duplicate', 'missing', 'unlisted', 'failed', 'notexcel', 'badformat', 'badentry'].some((key) => resp[key])) {
                 text = 'Import process completed with errors.';
             }
             [
@@ -35,7 +35,7 @@ function performAction(action) {
                 ['failed', 'failed to import.  Check if image file(s) are in an accepted WSI format']
             ].forEach(([key, desc]) => {
                 if (resp[key]) {
-                    if (key === 'unlisted' && !resp.parsed && !resp.notexcel) {
+                    if (key === 'unlisted' && !resp.parsed && !resp.notexcel && !resp.badformat) {
                         text += '  No DeID Upload file present.';
                     } else {
                         text += `  ${resp[key]} image${resp[key] > 1 ? 's' : ''} ${desc}.`;
@@ -45,7 +45,8 @@ function performAction(action) {
             });
             [
                 ['parsed', 'parsed'],
-                ['notexcel', 'could not be read']
+                ['notexcel', 'could not be read'],
+                ['badformat', 'incorrectly formatted']
             ].forEach(([key, desc]) => {
                 if (resp[key]) {
                     text += `  ${resp[key]} DeID Upload Excel file${resp[key] > 1 ? 's' : ''} ${desc}.`;


### PR DESCRIPTION
- The schema now restricts Proc_ID to 01-99 and Slide_ID to 01-20.
- The Export Jobs Folder wasn't being created.
- The listed overall report better matches the client report message.
- Blank rows are now allowed in DeID Upload files.
- Files starting with ~$ are ignored; these a Office temp files (also files with .xlk extension, which are Excel backup files).