### PR TITLE
Reduce transfer overhead.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,15 @@ commands:
 jobs:
   test:
     docker:
-      - image: girder/girder_test:latest
+      - image: girder/tox-and-node
       - image: circleci/mongo:4.0-ram
         command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/dev/shm/mongo"]
 
     steps:
       - checkout
+      - run:
+          name: Preinstall phantomjs to work around an npm permission issue
+          command: npm install -g phantomjs-prebuilt --unsafe-perm
       - run:
           name: Run server tests
           command: tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Improvements
+- Redaction and export are somewhat faster (#169)
+
 ## Version 2.1.1
 
 ### Changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,13 +26,13 @@ RUN curl -LJ https://github.com/krallin/tini/releases/download/v0.19.0/tini -o /
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install --no-install-recommends --yes \
-    python3.7 \
-    python3.7-distutils && \
+    python3.9 \
+    python3.9-distutils && \
     curl --silent https://bootstrap.pypa.io/get-pip.py -O && \
-    python3.7 get-pip.py && \
+    python3.9 get-pip.py && \
     rm get-pip.py && \
     rm /usr/bin/python3 && \
-    ln -s /usr/bin/python3.7 /usr/bin/python3 && \
+    ln -s /usr/bin/python3.9 /usr/bin/python3 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash && \
@@ -52,7 +52,7 @@ WORKDIR wsi_deid
 COPY . .
 
 # By using --no-cache-dir the Docker image is smaller
-RUN pip install --pre --no-cache-dir \
+RUN python3.9 -m pip install --pre --no-cache-dir \
     # Until https://github.com/cherrypy/cheroot/issues/312 is resolved.
     cheroot!=8.4.3,!=8.4.4 \
     # git+https://github.com/DigitalSlideArchive/DSA-WSI-DeID.git \
@@ -67,11 +67,11 @@ RUN pip install --pre --no-cache-dir \
 # Build the girder web client
 RUN girder build && \
     # Git rid of unnecessary files to keep the docker image smaller \
-    find /usr/local/lib/python3.7 -name node_modules -exec rm -rf {} \+ && \
+    find /usr/local/lib/python3.9 -name node_modules -exec rm -rf {} \+ && \
     rm -rf /tmp/npm*
 
 COPY ./devops/wsi_deid/girder.local.conf ./devops/wsi_deid/provision.py ./devops/wsi_deid/homepage.md /conf/
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 
-CMD python3 /conf/provision.py && (girder mount /fuse || true) && girder serve
+CMD python3.9 /conf/provision.py && (girder mount /fuse || true) && girder serve

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{36,37,38}
+  py{36,37,38,39}
   flake8
   lintclient
 skip_missing_interpreters = true


### PR DESCRIPTION
For export, we had been using shutil.copy2 for copying files.  Prior to Python 3.8, this internally uses a plain Python loop.  Python 3.8 and later use posix.sendfile.  In a linux docker under Windows, shutil.copy2 is slow; the sendfile method is worse than before by a factor of 3 or so in my test setup.  By using a subprocess and cp, in this environment we get roughly a factor of 2 faster than the pre 3.8 shutil function.

Further, python has a lot of overhead (in a linux docker under Windows) for each read call.  By aggregating reads together (see tifftools), we can save some of this overhead.