### PR TITLE
Make redacting a square on the macro an option

### DIFF
--- a/wsi_deid/web_client/stylesheets/ItemView.styl
+++ b/wsi_deid/web_client/stylesheets/ItemView.styl
@@ -36,7 +36,16 @@
   .g-widget-auximage-image img
     opacity 0.5
 
-.g-widget-auximage.redact-square
+.g-widget-auximage.redacted, .g-widget-auximage.redact-square
+  span.g-hui-redact-square-span
+    visibility visible
+
+.g-widget-auximage
+  span.g-hui-redact-square-span
+    visibility hidden
+    input[type="checkbox"].g-hui-redact-square
+      margin-left 10px
+      margin-right 5px
   .g-widget-auximage-image-redact-square
     position absolute
     left 0
@@ -49,10 +58,6 @@
       top 0
       right 0
       bottom 0
-      // black
-      // background-image url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQIHWNgAAAAAgABz8g15QAAAABJRU5ErkJggg==")
-      // white
-      background-image url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQIHWP4DwABAQEANl9ngAAAAABJRU5ErkJggg==")
       background-size contain
       background-repeat no-repeat
       opacity 0.5
@@ -63,14 +68,16 @@
     right 0
     bottom 0
     content "\a0"
-    background linear-gradient(to top left, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) calc(50% - 4px), rgba(0, 0, 0, 1) calc(50% - 3px), rgba(0, 0, 0, 1) calc(50% + 3px), rgba(0, 0, 0, 0) calc(50% + 4px), rgba(0, 0, 0, 0) 100%), linear-gradient(to top right, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) calc(50% - 4px), rgba(0, 0, 0, 1) calc(50% - 3px), rgba(0, 0, 0, 1) calc(50% + 3px), rgba(0, 0, 0, 0) calc(50% + 4px), rgba(0, 0, 0, 0) 100%)
 
-.g-widget-auximage.redact-square.redacted
+.g-widget-auximage.redact-square
   .g-widget-auximage-image-redact-square
     .fill
-      background none
+      // black
+      // background-image url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQIHWNgAAAAAgABz8g15QAAAABJRU5ErkJggg==")
+      // white
+      background-image url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVQIHWP4DwABAQEANl9ngAAAAABJRU5ErkJggg==")
   .g-widget-auximage-image-redact-square:after
-    background none
+    background linear-gradient(to top left, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) calc(50% - 4px), rgba(0, 0, 0, 1) calc(50% - 3px), rgba(0, 0, 0, 1) calc(50% + 3px), rgba(0, 0, 0, 0) calc(50% + 4px), rgba(0, 0, 0, 0) 100%), linear-gradient(to top right, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) calc(50% - 4px), rgba(0, 0, 0, 1) calc(50% - 3px), rgba(0, 0, 0, 1) calc(50% + 3px), rgba(0, 0, 0, 0) calc(50% + 4px), rgba(0, 0, 0, 0) 100%)
 
 .g-widget-metadata-container.workflow .g-workflow-button
   margin 10px

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -99,7 +99,7 @@ wrap(ItemView, 'render', function (render) {
         target.closest('.g-widget-auximage').toggleClass('redacted', isRedacted && !redactSquare);
         target.closest('.g-widget-auximage').toggleClass('redact-square', !!redactSquare);
         target.closest('.g-widget-auximage').find('input[type="checkbox"]').prop('checked', !!redactSquare);
-        return isSquare && $(event.currentTarget).is('input[type="checkbox"]');
+        return isSquare && $(event.target).is('input[type="checkbox"]');
     };
 
     const showRedactButton = (keyname) => {
@@ -192,6 +192,21 @@ wrap(ItemView, 'render', function (render) {
         window.setTimeout(() => resizeRedactSquare(elem), 1000);
     };
 
+    const resizeRedactBackground = (elem) => {
+        let image = elem.find('.g-widget-auximage-image img');
+        if (!image.length) {
+            return;
+        }
+        let minwh = Math.min(image.width(), image.height());
+        if (minwh > 0) {
+            let redact = elem.find('.g-widget-auximage-image');
+            redact.width(image.width());
+            redact.height(image.height());
+            return;
+        }
+        window.setTimeout(() => resizeRedactBackground(elem), 1000);
+    };
+
     const addRedactionControls = (showControls, settings) => {
         /* if showControls is false, the tabs are still adjusted and some
          * fields may be hidden, but the actual redaction controls aren't
@@ -233,6 +248,7 @@ wrap(ItemView, 'render', function (render) {
                 elem = $(elem);
                 let keyname = elem.attr('auximage');
                 elem.find('.g-hui-redact').remove();
+                resizeRedactBackground(elem);
                 let isRedacted = redactList.images[keyname] !== undefined;
                 if (keyname !== 'label' || !settings.always_redact_label) {
                     addRedactButton(elem.find('.g-widget-auximage-title'), keyname, redactList.images[keyname], 'images', settings);

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -55,25 +55,34 @@ wrap(ItemView, 'render', function (render) {
 
     const flagRedaction = (event) => {
         event.stopPropagation();
-        const target = $(event.currentTarget);
+        let target = $(event.currentTarget);
+        const isSquare = target.is('.g-hui-redact-square,.g-hui-redact-square-span');
+        if (isSquare) {
+            target = target.closest('.g-hui-redact-label').find('.g-hui-redact');
+        }
         const keyname = target.attr('keyname');
         const category = target.attr('category');
         let reason = target.val();
         const redactList = this.getRedactList();
         let isRedacted = redactList[category][keyname] !== undefined;
-        if (target.is('a')) { // button, not select
-            reason = isRedacted ? 'none' : 'No_Reason_Collected';
-        }
-        if (isRedacted && (!reason || reason === 'none')) {
-            delete redactList[category][keyname];
-            isRedacted = false;
-        } else if ((!isRedacted || redactList[category][keyname].reason !== reason) && reason && reason !== 'none') {
-            redactList[category][keyname] = { value: null, reason: reason, category: $(':selected', target).attr('category') || reason };
-            isRedacted = true;
+        if (isSquare) {
+            redactList[category][keyname].square = !redactList[category][keyname].square;
         } else {
-            // no change
-            return;
+            if (target.is('a')) { // button, not select
+                reason = isRedacted ? 'none' : 'No_Reason_Collected';
+            }
+            if (isRedacted && (!reason || reason === 'none')) {
+                delete redactList[category][keyname];
+                isRedacted = false;
+            } else if ((!isRedacted || redactList[category][keyname].reason !== reason) && reason && reason !== 'none') {
+                redactList[category][keyname] = { value: null, reason: reason, category: $(':selected', target).attr('category') || reason };
+                isRedacted = true;
+            } else {
+                // no change
+                return;
+            }
         }
+        const redactSquare = (redactList[category][keyname] || {}).square || (!isRedacted && target.closest('.g-widget-auximage').hasClass('always-redact-square'));
         restRequest({
             method: 'PUT',
             url: 'wsi_deid/item/' + this.model.id + '/redactList',
@@ -87,8 +96,10 @@ wrap(ItemView, 'render', function (render) {
         this.model.get('meta').redactList = redactList;
         target.closest('td.large_image_metadata_value').toggleClass('redacted', isRedacted);
         target.closest('td.large_image_metadata_value').find('.redact-replacement').remove();
-        target.closest('.g-widget-auximage').toggleClass('redacted', isRedacted);
-        return false;
+        target.closest('.g-widget-auximage').toggleClass('redacted', isRedacted && !redactSquare);
+        target.closest('.g-widget-auximage').toggleClass('redact-square', !!redactSquare);
+        target.closest('.g-widget-auximage').find('input[type="checkbox"]').prop('checked', !!redactSquare);
+        return isSquare && $(event.currentTarget).is('input[type="checkbox"]');
     };
 
     const showRedactButton = (keyname) => {
@@ -228,17 +239,32 @@ wrap(ItemView, 'render', function (render) {
                 } else {
                     isRedacted = true;
                 }
-                if (keyname === 'macro' && settings.redact_macro_square) {
-                    elem.addClass('redact-square');
+                let redactSquare = false;
+                if (keyname === 'macro') {
                     let redactsquare = $('<div class="g-widget-auximage-image-redact-square" title="This region will be blacked out"><div class="fill">&nbsp;</div></div>');
                     elem.find('.g-widget-auximage-image').append(redactsquare);
                     resizeRedactSquare(elem);
+                    if (!settings.redact_macro_square) {
+                        let check = $('<span class="g-hui-redact-square-span"><input type="checkbox" class="g-hui-redact-square"></input>Partial</span>');
+                        if ((redactList.images[keyname] || {}).square) {
+                            check.find('input[type="checkbox"]').prop('checked', true);
+                            redactSquare = true;
+                        }
+                        elem.find('.g-widget-auximage-title .g-hui-redact-label').append(check);
+                    } else {
+                        redactSquare = true;
+                        elem.addClass('always-redact-square');
+                    }
+                    if (redactSquare) {
+                        elem.addClass('redact-square');
+                    }
                 }
-                elem.toggleClass('redacted', isRedacted);
+                elem.toggleClass('redacted', isRedacted && !redactSquare);
             });
             this.events['input .g-hui-redact'] = flagRedaction;
             this.events['change .g-hui-redact'] = flagRedaction;
             this.events['click a.g-hui-redact'] = flagRedaction;
+            this.events['click .g-hui-redact-square-span'] = flagRedaction;
             this.events['click .g-hui-redact-label'] = (event) => {
                 event.stopPropagation();
                 return false;


### PR DESCRIPTION
If the ini setting to always redact a square of the macro image is not enabled, then there is a "partial" checkbox that can be selected when redacting the macro image.