### PR TITLE
Use trivy to scan docker image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,25 @@ jobs:
               docker tag dsarchive/wsi_deid:latest dsarchive/wsi_deid:stable
               docker push dsarchive/wsi_deid:stable
               fi
+  scan-docker:
+    docker:
+      - image: docker:stable-git
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Install trivy
+          command: |
+            apk add --update-cache --upgrade curl
+            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+      - run:
+          name: Scan the local image with trivy; fail on high or critical vulnerabilities
+          command: trivy image --input /tmp/workspace/wsi_deid_girder.tar --exit-code 1 --severity HIGH,CRITICAL --no-progress
+      - run:
+          name: Scan the local image with trivy; report low and medium vulnerabilities, but don't fail
+          command: trivy image --input /tmp/workspace/wsi_deid_girder.tar --exit-code 0 --severity LOW,MEDIUM,UNKNOWN --no-progress
 
 workflows:
   version: 2
@@ -104,10 +123,17 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - scan-docker:
+          requires:
+            - docker-compose
+          filters:
+            tags:
+              only: /^v.*/
       - publish-docker:
           requires:
             - test
             - docker-compose
+            - scan-docker
           filters:
             tags:
               only: /^v.*/
@@ -125,7 +151,11 @@ workflows:
     jobs:
       - test
       - docker-compose
+      - scan-docker:
+          requires:
+            - docker-compose
       - publish-docker:
           requires:
             - test
             - docker-compose
+            - scan-docker

--- a/docs/INSTALL.rst
+++ b/docs/INSTALL.rst
@@ -230,3 +230,12 @@ Redaction Business Rules
 Some metadata fields are automatically modified by default.  For example, certain dates are converted to always be January 1st of the year of the original date.  Embedded titles and filenames are replaced with a specified Image ID.  Some of these modifications vary by WSI vendor format.
 
 To modify these business rules, it is recommended that this repository is forked or an additional python module is created that alters the ``get_standard_redactions`` function and the vendor-specific variations of that function (e.g., ``get_standard_redactions_format_aperio``) located in the `process.py <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/wsi_deid/process.py>`_ source file.
+
+Vulnerability Security
+======================
+
+Since the program is installed and run using Docker, most of its security is dependent on Docker.  The standard deployment uses some standard docker images including MongoDB and Memcached.  These imagess are produced by external sources and are scanned for vulnerabilities by Docker.  There is one custom image used by this program that is created as part of a Continuous Integration (CI) pipeline.  As part of the CI process, this container is scanned for vulnerabilities.
+
+The CI process uses `trivy <https://aquasecurity.github.io/trivy>`_ to scan the generated docker image for vulnerabilities.  This uses standard public databases of known problems (see the list of Data Sources on Trivy).  Other tools, such as ``docker scan`` use these same databases of issues.  The CI process ensures that there are no high- or critical-level issues before publishing the docker image.  Low- and medium- level issues are periodically reviewed to ensure that they are either inapplicable or guarded in an alternate manner.  For example, there are warnings about nodejs server, but this is not used -- nodejs is used internally as part of the build process, but the server is not part of the running software and therefore issues with the nodejs server cannot affect the final program.
+
+Although due diligence is made to check for security issues, no guarantee is made.  Future exploits may be discovered or go unreported and could affect the packaged image.


### PR DESCRIPTION
Use trivy in preference to "docker scan" as it doesn't require as much setup (e.g., no account).  Fail on high and critical issues; report
other issues.

This adds a few paragraphs to the installation documentation discussing the security scan.