### PR TITLE
Update USAGE docs for consistency

### DIFF
--- a/docs/USAGE.rst
+++ b/docs/USAGE.rst
@@ -356,9 +356,9 @@ These business rules will be automatically applied at the time of data import to
 
 The following rules apply to all file formats:
 
-* Tiff ``DateTime`` (if present), set to 01:01:(year and time)
-* ``Copyright``: removed
-* ``HostComputer``: removed
+* ``tiff.DateTime`` (if present), set to 01:01:(year and time)
+* ``tiff.Copyright``: removed
+* ``tiff.HostComputer``: removed
 * ``tiff.Software``: modified by adding custom tags with data from the DeID Upload file
 
 These rules apply only to Aperio files:

--- a/docs/USAGE.rst
+++ b/docs/USAGE.rst
@@ -57,9 +57,9 @@ If you are logged into the WSI DeID, your username will appear in the upper righ
 User Types and Permissions
 --------------------------
 
-See GIRDER.rst for more information.
+See `GIRDER.rst <GIRDER.rst>`_ for more information.
 
-**Admin User:** The first registered user of a WSI DeID system will be an ``admin`` user and will have super-user privileges, meaning that the user can take any actions on the system. Admin users can change permissions of other users in the system and can reset users' passwords. The Admin user should be tied to an IT support staff member, and users of the system should create Non-Super Users.
+**Admin User:** The first registered user of a WSI DeID system will be an Admin user and will have super-user privileges, meaning that the user can take any actions on the system. Admin users can change permissions of other users in the system and can reset users' passwords. The Admin user should be tied to an IT support staff member, and users of the system should create Non-Super Users.
 
 **Non-Super Users:** All subsequently created users will be Non-Super Users, who will have the ability to use the redaction workflows.
 
@@ -69,7 +69,7 @@ Workflow Overview
 
 There are six Folders an image file can be in within the WSI DeID Tool, including:
 
-- ``Available To Process``
+- ``AvailableToProcess``
 - ``Quarantined``
 - ``Redacted``
 - ``Rejected``
@@ -91,18 +91,18 @@ The users will place original WSIs along with an Excel metadata file (the DeID U
 Step 2 Users Import Files
 -------------------------
 
-Users navigate to the ``Available To Process`` folder in the WSI DeID and then follow the import process to import files into the system. See the Importing Data section for more information. If the images have import errors, then importing errors will be displayed, and the files will not be imported. Corrective action must be taken to fix the files before they can be imported.
+Users navigate to the ``AvailableToProcess`` folder in the WSI DeID and then follow the import process to import files into the system. See the Importing Data section for more information. If the images have import errors, then importing errors will be displayed, and the files will not be imported. Corrective action must be taken to fix the files before they can be imported.
 
-When an image is first imported into the WSI DeID from the host filesystem, it will be renamed according to the import process and will be in the ``Available To Process`` folder.
+When an image is first imported into the WSI DeID from the host filesystem, it will be renamed according to the import process and will be in the ``AvailableToProcess`` folder.
 
 Step 3 Users Process and Deidentify Files
 -----------------------------------------
 
-Once an image is in the ``Available To Process`` folder, the user can make the following selections in the User Interface (UI):
+Once an image is in the ``AvailableToProcess`` folder, the user can make the following selections in the User Interface (UI):
 
-- "Redact Image" to redact it, sending it to the ``Redacted`` folder, and sending an original file to the ``Original`` folder (go to step 4)
-- "Quarantine" for more reprocessing, sending it to the ``Quarantined`` folder (go to step 4a)
-- "Reject" to mark that it is impossible to fix, sending it to the ``Rejected`` folder (go to Step 4b)
+- ``Redact Image`` to redact it, sending it to the ``Redacted`` folder, and sending an original file to the ``Original`` folder (go to step 4)
+- ``Quarantine`` for more reprocessing, sending it to the ``Quarantined`` folder (go to step 4a)
+- ``Reject`` to mark that it is impossible to fix, sending it to the ``Rejected`` folder (go to Step 4b)
 
 An image is copied into the ``Original`` folder before it will be redacted and will go into the ``Redacted`` folder, so that an unedited copy of the image is stored.
 
@@ -113,13 +113,13 @@ Images in the ``Redacted`` folder have gone through the redaction process but sh
 
 Once an image is in the ``Redacted`` folder, the user can approve the file. The user can make the following UI selections:
 
-- "Approve" to approve it, once it has been fully cleared for release. If this is pressed, then the image will move to the ``Approved`` folder, and then the view will change to the next image to be processed, as if you had clicked on the ``Next Item`` action in the left menu.
-- "Quarantine" for more reprocessing, sending it to the ``Quarantined`` folder (go to step 4a)
+- ``Approve`` to approve it, once it has been fully cleared for release. If this is pressed, then the image will move to the ``Approved`` folder, and then the view will change to the next image to be processed, as if you had clicked on the ``Next Item`` action in the left menu.
+- ``Quarantine`` for more reprocessing, sending it to the ``Quarantined`` folder (go to step 4a)
 
 Step 4a Users Contact IMS and Reprocess for Potential Resolution
 ----------------------------------------------------------------
 
-The ``Quarantined`` folder is for holding images that may hold PHI/PII. Users should contact IMS via Squish (`https://www.squishlist.com/seerdms/support/ <https://www.squishlist.com/seerdms/support/>`__) for any WSI files in the ``Quarantined`` folder, and then review files for reprocessing based on instructions from IMS. If PHI/PII is seen in an image or metadata field, that is somewhere other than the ``Available To Process`` folder, it should be quarantined for reprocessing. For definitions of PHI/PII categories available for recaction, refer to the `PHI/PII Definitions and Types section <#phipii-definitions-and-types>`__ of these usage instructions below.
+The ``Quarantined`` folder is for holding images that may hold PHI/PII. Users should contact IMS via Squish (`https://www.squishlist.com/seerdms/support/ <https://www.squishlist.com/seerdms/support/>`__) for any WSI files in the ``Quarantined`` folder, and then review files for reprocessing based on instructions from IMS. If PHI/PII is seen in an image or metadata field, that is somewhere other than the ``AvailableToProcess`` folder, it should be quarantined for reprocessing. For definitions of PHI/PII categories available for recaction, refer to the `PHI/PII Definitions and Types section <#phipii-definitions-and-types>`__ of these usage instructions below.
 
 Any time a WSI file has been quarantined, the source folder it was quarantined from will remain. This explains why some empty folders may be encountered in the system, that previously had WSI files in them.
 
@@ -128,9 +128,9 @@ Step 4b Users Review and Re-process Rejected Files After Software Updates
 
 The ``Rejected`` folder  is available at any time.
 
-There are two ways an image needs to be rejected: (a) there is PHI in the zoomable image in the WSI (e.g., someone wrote the patient name on the slide itself), or (b) there is PHI in a metadata field that is shown, but the software does not offer a redaction control for. In either of these cases, the image can be sent to the ``Rejected`` folder by clicking on the ``rejected`` button. Users should contact IMS for any WSI files in the ``Rejected`` folder.
+There are two ways an image needs to be rejected: (a) there is PHI in the zoomable image in the WSI (e.g., someone wrote the patient name on the slide itself), or (b) there is PHI in a metadata field that is shown, but the software does not offer a redaction control for. In either of these cases, the image can be sent to the ``Rejected`` folder by clicking on the ``Reject`` button. Users should contact IMS for any WSI files in the ``Rejected`` folder.
 
-There is a ``Reject`` button available near the zoomable WSI image as a convenience to quickly reject a WSI file, see the screenshot below.
+The ``Reject`` button is available near the zoomable WSI image as a convenience to quickly reject a WSI file. See the screenshot below.
 
 .. image:: screenshots/top_reject_button.png
    :alt: top reject button
@@ -159,26 +159,26 @@ After clicking on the ``WSI DeID`` collection link, you will be in the ``WSI DeI
 .. image:: screenshots/wsideid_collection_folders_highlighted.png
    :alt: WSI DeID collection folders
 
-From this folder listing, you can navigate to any folder you wish by clicking on the folder name link. For example, if you want to import data, go to the ``AvailableToProcess`` folder, or if you want to export data, go to the ``Approved`` folder. See the Workflow Overview section above for a description of each folder.
+From this folder listing, you can navigate to any folder you wish by clicking on the folder name link. For example, if you want to import data, go to the ``AvailableToProcess`` folder, or if you want to export data, go to the ``Approved`` folder. See the `Workflow Overview <#workflow-overview>`__ section above for a description of each folder.
 
 Next Item Action
 ----------------
 
 Clicking on the ``Next Item`` link on the left menu will bring you to view the first image in the ``AvailableToProcess`` folder, or else the first image in the ``Quarantined`` folder if there are no images in the ``AvailableToProcess`` folder.
 
-For descriptions of other actions in the left menu, see GIRDER.rst.
+For descriptions of other actions in the left menu, see `GIRDER.rst <GIRDER.rst>`_.
 
 Folder Versus Item Views
 ------------------------
 
-The WSI DeID is based on Girder (see GIRDER.rst for more information), which is structured as Folders and Items. **Folders** are similar to a directory on your local computer's filesystem; whereas, **Items** are a container for one or more files, such as would be on your local computer's filesystem. For the purposes of the WSI DeID documentation, an image is an item and  may be used interchangeably. A whole slide image file may contain multiple images, such as in the case where there is a primary image and associated images, such as a label or macro image.
+The WSI DeID is based on Girder (see `GIRDER.rst <GIRDER.rst>`_ for more information), which is structured as folders and items. **Folders** are similar to a directory on your local computer's filesystem, whereas **items** are a container for one or more files, such as would be on your local computer's filesystem. For the purposes of the WSI DeID documentation, an image is an item and  may be used interchangeably. A whole slide image file may contain multiple images, such as in the case where there is a primary image and associated images, such as a label or macro image.
 
-A folder in Girder may contain items, and an item always has to be in a folder. When looking at the WSI DeID, if you are in a folder, you will see the folder icon on the upper right of the screen, as shown in the screenshot below taken from an ``AvailableToProcess`` folder. In this case, the folder has zero children folders and two items within the folder, which is why there is an icon of a folder with a ``0`` and an icon of a document with a ``2`` in the screenshot.
+A folder in Girder may contain items, and an item always has to be in a folder. When looking at the WSI DeID, if you are in a folder, you will see the folder icon on the upper right of the screen, as shown in the screenshot below taken from an ``AvailableToProcess`` folder. In this case, the folder has zero child folders and two items within the folder, which is why there is an icon of a folder with a ``0`` and an icon of a document with a ``2`` in the screenshot.
 
 .. image:: screenshots/folder_view_highlighted.png
    :alt: image folder view
 
-To see an item view of an image, click on the image/item's row in the folder view. You will then go to the item view, which looks like the below screenshot, of an item (a WSI file) named ``0579XY112001_01_13.svs`` that is located in the ``AvailableToProcess`` folder. In the info panel, you can see some metadata such as the image size and WSI DeID creation date. The item view will present you with subsections for a panning/zooming ``Image Viewer``, a listing of ``Large Image Metadata``, the set of ``Associated Images``, and image/item specific ``WSI DeID Workflow`` actions.
+To see an item view of an image, click on the image/item's row in the folder view. You will then go to the item view, which looks like the screenshot below, of an item (a WSI file) named ``0579XY112001_01_13.svs`` that is located in the ``AvailableToProcess`` folder. In the info panel, you can see some metadata such as the image size and WSI DeID creation date. The item view will present you with subsections for a panning/zooming ``Image Viewer``, a listing of ``Large Image Metadata``, the set of ``Associated Images``, and image/item specific ``WSI DeID Workflow`` actions.
 
 .. image:: screenshots/example_image_item_view.png
    :alt: image item view
@@ -188,7 +188,7 @@ Below is a screenshot of the action buttons available in the ``WSI DeID Workflow
 .. image:: screenshots/wsideid_workflow_buttons_highlighted.png
    :alt: WSI DeID workflow buttons
 
-Files & links Actions
+Files & Links Actions
 ---------------------
 
 There is a section of the WSI DeID that is titled ``Files & links``. Do not click on any of the buttons in this section unless you are intentionally performing low-level file management. These buttons are shown yellow box highlighted in the screenshot below.
@@ -222,7 +222,7 @@ See the Navigating the WSI DeID section above for more information.
 Step 3 Press the Import Button
 ------------------------------
 
-From the ``AvailableToProcess`` folder (or any sub folder) in the WSI DeID, click on the ``Import`` button, as shown in the below screenshot.
+From the ``AvailableToProcess`` folder (or any sub folder) in the WSI DeID, click on the ``Import`` button, as shown in the screenshot below.
 
 .. image:: screenshots/import_button_highlighted.png
    :alt: import button
@@ -248,7 +248,7 @@ After the WSI file names and information in the DeID Upload file are reconciled,
 Step 4 Import Status is Displayed
 ---------------------------------
 
-After all images and all DeID Upload files have been processed, a message is displayed summarizing what images were in each of the classifications above (e.g., "Import completed. 3 images added. 1 DeID Upload Excel file parsed. See the Excel file report for more details.). If you click on the "See the Excel report for more details" link, it will download an import report, which will indicate which WSIs were imported or which failed to import and why. Users should review this report for any issues as outlined above.
+After all images and all DeID Upload files have been processed, a message is displayed summarizing what images were in each of the classifications above (e.g., "Import completed. 3 images added. 1 DeID Upload Excel file parsed. See the Excel file report for more details."). If you click on the "See the Excel report for more details" link, it will download an import report, which will indicate which WSIs were imported or which failed to import and why. Users should review this report for any issues as outlined above.
 
 The user may then proceed with the redaction workflow, described in the Workflow Overview section above.
 
@@ -261,7 +261,7 @@ Below is a screenshot of a message presented to the user after an import. See th
 Redaction
 =========
 
-At a high level in the Redaction process, the user can inspect the image and metadata for PHI/PII, and can indicate if any of these should be redacted. Redaction can occur from the ``Available To Process`` or ``Quarantined`` folder. Below are the specific steps to follow for the Redaction process. When a field is redacted so that it is changed, the original value in that redacted data field is completely replaced with the new value. When a field or image is redacted completely, it is removed and will not be available in the future.
+At a high level in the Redaction process, the user can inspect the image and metadata for PHI/PII, and can indicate if any of these should be redacted. Redaction can occur from the ``AvailableToProcess`` or ``Quarantined`` folder. Below are the specific steps to follow for the Redaction process. When a field is redacted so that it is changed, the original value in that redacted data field is completely replaced with the new value. When a field or image is redacted completely, it is removed and will not be available in the future.
 
 Review Process for PHI/PII in Image(s) and Metadata
 ---------------------------------------------------
@@ -270,15 +270,15 @@ Review Process for PHI/PII in Image(s) and Metadata
 
 2. Review the image(s) and metadata fields for PHI/PII. Definitions of PHI/PII categories in the redaction drop-down menu are listed in the `PHI/PII Definitions and Types section <#phipii-definitions-and-types>`__.
 
-  2.1. Review the zoomable image (top image after opening the WSI file). If the low-resolution image at the top of the screen (see screenshot below) contains PHI/PII, then click ``Reject``. If there is no PHI/PII, then go on to the next step. You may zoom and pan in the low-resolution image to see areas of the image in higher resolution.
+   2.1. Review the zoomable image (top image after opening the WSI file). If the low-resolution image at the top of the screen (see screenshot below) contains PHI/PII, then click ``Reject``. If there is no PHI/PII, then go on to the next step. You may zoom and pan in the low-resolution image to see areas of the image in higher resolution.
 
-  2.2. Review metadata for PHI/PII, by scrolling down below the main image to the metadata section display. Some metadata fields will be automatically pre-redacted upon import, including titles and dates that are specific to each scanner manufacturer. See the Business Rules for WSI DeID section below for details.
+   2.2. Review metadata for PHI/PII, by scrolling down below the main image to the metadata section display. Some metadata fields will be automatically pre-redacted upon import, including titles and dates that are specific to each scanner manufacturer. See the Business Rules for WSI DeID section below for details.
 
-  The user can view metadata fields, and if any of these contain PHI/PII, the user should select the classification of PHI in the redact control for that field (see the PHI/PII Definitions and Types, below). The metadata field will then have a line through the text, indicating that the field will be redacted (it has been marked for redaction).
+   The user can view metadata fields, and if any of these contain PHI/PII, the user should select the classification of PHI in the redact control for that field (see the PHI/PII Definitions and Types, below). The metadata field will then have a line through the text, indicating that the field will be redacted (it has been marked for redaction).
 
-  2.3. Scroll down to the bottom of the screen and review the associated images (label, macro, and thumbnail).  If you see PHI/PII in individual associated images, select the classification of PHI in the image from the redact control. The image will show an X through it to indicate that it will be redacted.
+   2.3. Scroll down to the bottom of the screen and review the associated images (label, macro, and thumbnail).  If you see PHI/PII in individual associated images, select the classification of PHI in the image from the redact control. The image will show an X through it to indicate that it will be redacted.
 
-  2.4. When redaction decisions have been made for all images and metadata, the user should click the ``Redact Image`` button, which will make a copy of the existing image and place that copy in the ``Original`` folder, and will move the image to the ``Redacted`` folder. As part of moving the data to the ``Redacted`` folder, the metadata fields and associated images that have been marked for redaction will be deleted.
+   2.4. When redaction decisions have been made for all images and metadata, the user should click the ``Redact Image`` button, which will make a copy of the existing image and place that copy in the ``Original`` folder, and will move the image to the ``Redacted`` folder. As part of moving the data to the ``Redacted`` folder, the metadata fields and associated images that have been marked for redaction will be deleted.
 
 3. If after redacting, all PHI/PII has been removed, click the green ``Approved`` button.
 
@@ -356,29 +356,29 @@ These business rules will be automatically applied at the time of data import to
 
 The following rules apply to all file formats:
 
-* Tiff DateTime (if present), set to 01:01:(year and time)
-* Copyright: removed
-* HostComputer: removed
-* tiff.Software: modified by adding custom tags with data from the DeID Upload file
+* Tiff ``DateTime`` (if present), set to 01:01:(year and time)
+* ``Copyright``: removed
+* ``HostComputer``: removed
+* ``tiff.Software``: modified by adding custom tags with data from the DeID Upload file
 
 These rules apply only to Aperio files:
 
-* aperio.Filename: change or add to ImageID
-* aperio.Title: change or add to ImageID
-* aperio.Date (if present), set to 01/01/(year)
+* ``aperio.Filename``: change or add to ImageID
+* ``aperio.Title``: change or add to ImageID
+* ``aperio.Date`` (if present), set to 01/01/(year)
 
 These rules apply only to Hamamatsu files:
 
-* hamamatsu.Reference: change or add to ImageID
-* hamamatsu.Created (if present): set to (year)/01/01
-* hamamatsu.Updated (if present): set to (year)/01/01
+* ``hamamatsu.Reference``: change or add to ImageID
+* ``hamamatsu.Created`` (if present): set to (year)/01/01
+* ``hamamatsu.Updated`` (if present): set to (year)/01/01
 
 These rules apply only to Philips files:
 
-* PIIM_DP_SCANNER_OPERATOR_ID: change or add to ImageID
-* PIM_DP_UFS_BARCODE: change or add to ImageID
-* DICOM_DATE_OF_LAST_CALIBRATION (if present): set to (year)0101
-* DICOM_ACQUISITION_DATETIME (if present): set to (year)0101 (time)
+* ``PIIM_DP_SCANNER_OPERATOR_ID``: change or add to ImageID
+* ``PIM_DP_UFS_BARCODE``: change or add to ImageID
+* ``DICOM_DATE_OF_LAST_CALIBRATION`` (if present): set to (year)0101
+* ``DICOM_ACQUISITION_DATETIME`` (if present): set to (year)0101 (time)
 
 
 Below is a screenshot of image PHI/PII redaction controls for metadata.


### PR DESCRIPTION
Closes #59 
The following changes have been made to improve consistency within the USAGE docs

1. The word 'Admin' in the phrase 'Admin user' no longer has backticks
2. Any reference to another part of this documentation or other DSA WSI DeID documentation is now a link
3. All instances of 'Available To Process' have been changed to `AvailableToProcess`
4. All button titles are now in backticks
5.  Metadata field names are now in backticks
6. Some punctuation errors, formatting, and grammar issues have been resolved