### PR TITLE
Add config to enable redaction and hide metadata

### DIFF
--- a/devops/wsi_deid/girder.local.conf
+++ b/devops/wsi_deid/girder.local.conf
@@ -25,3 +25,23 @@ enabled = True
 redact_macro_square = False
 always_redact_label = False
 require_redact_category = True
+no_redact_control_keys: [
+        r'^internal;aperio_version$',
+        r'^internal;openslide;openslide\.(?!comment$)',
+        r'^internal;openslide;tiff.(ResolutionUnit|XResolution|YResolution)$',
+    ],
+no_redact_control_keys_format_aperio: [
+        r'^internal;openslide;aperio.AppMag',
+],
+no_redact_control_keys_format_hamamatsu: [],
+no_redact_control_keys_format_philips: [],
+hide_metadata_keys: [
+    r'^internal;openslide;openslide.level\[',
+],
+hide_metadata_keys_format_aperio: [
+    r'^internal;openslide;(openslide.comment|tiff.ImageDescription)$',
+],
+hide_metadata_keys_format_hamamatsu: [
+    r'^internal;openslide;hamamatsu.(AHEX|MHLN)\[',
+],
+hide_metadata_keys_format_philips: [],

--- a/devops/wsi_deid/girder.local.conf
+++ b/devops/wsi_deid/girder.local.conf
@@ -26,12 +26,16 @@ redact_macro_square = False
 always_redact_label = False
 require_redact_category = True
 no_redact_control_keys = [
+    "^internal;aperio_version$",
     "^internal;openslide;openslide\.(?!comment$)",
-    "^internal;openslide;tiff.(ResolutionUnit|XResolution|YResolution)$"]
-no_redact_control_keys_format_aperio = ["^internal;aperio_version$", "^internal;openslide;aperio.AppMag"]
-no_redact_control_keys_format_hamamatsu = []
+    "^internal;openslide;tiff\.(ResolutionUnit|XResolution|YResolution)$"]
+no_redact_control_keys_format_aperio = [
+    "^internal;openslide;aperio\.(AppMag|MPP|Exposure (Time|Scale))$"]
+no_redact_control_keys_format_hamamatsu = ["^internal;openslide;hamamatsu\.SourceLens$"]
 no_redact_control_keys_format_philips = []
-hide_metadata_keys = ["^internal;openslide;openslide.level\["]
-hide_metadata_keys_format_aperio = ["^internal;openslide;(openslide.comment|tiff.ImageDescription)$"]
-hide_metadata_keys_format_hamamatsu = ["^internal;openslide;hamamatsu.(AHEX|MHLN)\["]
+hide_metadata_keys = ["^internal;openslide;openslide\.level\["]
+hide_metadata_keys_format_aperio = [
+    "^internal;openslide;(openslide\.comment|tiff\.ImageDescription)$",
+    "^internal;openslide;aperio\.(Original(Height|Width)|Left|Top|Right|Bottom|LineArea(X|Y)Offset|LineCameraSkew|Focus Offset|StripeWidth)"]
+hide_metadata_keys_format_hamamatsu = ["^internal;openslide;hamamatsu\.((AHEX|MHLN|YRNP|zCoarse|zFine)\[|(X|Y)OffsetFromSlideCentre|ccd.(width|height)|(focalplane|slant)\.(left|right)(top|bottom)|stage.center)"]
 hide_metadata_keys_format_philips = []

--- a/devops/wsi_deid/girder.local.conf
+++ b/devops/wsi_deid/girder.local.conf
@@ -25,23 +25,13 @@ enabled = True
 redact_macro_square = False
 always_redact_label = False
 require_redact_category = True
-no_redact_control_keys: [
-        r'^internal;aperio_version$',
-        r'^internal;openslide;openslide\.(?!comment$)',
-        r'^internal;openslide;tiff.(ResolutionUnit|XResolution|YResolution)$',
-    ],
-no_redact_control_keys_format_aperio: [
-        r'^internal;openslide;aperio.AppMag',
-],
-no_redact_control_keys_format_hamamatsu: [],
-no_redact_control_keys_format_philips: [],
-hide_metadata_keys: [
-    r'^internal;openslide;openslide.level\[',
-],
-hide_metadata_keys_format_aperio: [
-    r'^internal;openslide;(openslide.comment|tiff.ImageDescription)$',
-],
-hide_metadata_keys_format_hamamatsu: [
-    r'^internal;openslide;hamamatsu.(AHEX|MHLN)\[',
-],
-hide_metadata_keys_format_philips: [],
+no_redact_control_keys = [
+    "^internal;openslide;openslide\.(?!comment$)",
+    "^internal;openslide;tiff.(ResolutionUnit|XResolution|YResolution)$"]
+no_redact_control_keys_format_aperio = ["^internal;aperio_version$", "^internal;openslide;aperio.AppMag"]
+no_redact_control_keys_format_hamamatsu = []
+no_redact_control_keys_format_philips = []
+hide_metadata_keys = ["^internal;openslide;openslide.level\["]
+hide_metadata_keys_format_aperio = ["^internal;openslide;(openslide.comment|tiff.ImageDescription)$"]
+hide_metadata_keys_format_hamamatsu = ["^internal;openslide;hamamatsu.(AHEX|MHLN)\["]
+hide_metadata_keys_format_philips = []

--- a/devops/wsi_deid/girder.local.conf
+++ b/devops/wsi_deid/girder.local.conf
@@ -36,6 +36,6 @@ no_redact_control_keys_format_philips = []
 hide_metadata_keys = ["^internal;openslide;openslide\.level\["]
 hide_metadata_keys_format_aperio = [
     "^internal;openslide;(openslide\.comment|tiff\.ImageDescription)$",
-    "^internal;openslide;aperio\.(Original(Height|Width)|Left|Top|Right|Bottom|LineArea(X|Y)Offset|LineCameraSkew|Focus Offset|StripeWidth)"]
+    "^internal;openslide;aperio\.(Original(Height|Width)|Left|Top|Right|Bottom|LineArea(X|Y)Offset|LineCameraSkew|Focus Offset|StripeWidth|DisplayColor)"]
 hide_metadata_keys_format_hamamatsu = ["^internal;openslide;hamamatsu\.((AHEX|MHLN|YRNP|zCoarse|zFine)\[|(X|Y)OffsetFromSlideCentre|ccd.(width|height)|(focalplane|slant)\.(left|right)(top|bottom)|stage.center)"]
 hide_metadata_keys_format_philips = []

--- a/devops/wsi_deid/girder.local.conf
+++ b/devops/wsi_deid/girder.local.conf
@@ -25,17 +25,21 @@ enabled = True
 redact_macro_square = False
 always_redact_label = False
 require_redact_category = True
-no_redact_control_keys = [
-    "^internal;aperio_version$",
-    "^internal;openslide;openslide\.(?!comment$)",
-    "^internal;openslide;tiff\.(ResolutionUnit|XResolution|YResolution)$"]
-no_redact_control_keys_format_aperio = [
-    "^internal;openslide;aperio\.(AppMag|MPP|Exposure (Time|Scale))$"]
-no_redact_control_keys_format_hamamatsu = ["^internal;openslide;hamamatsu\.SourceLens$"]
-no_redact_control_keys_format_philips = []
-hide_metadata_keys = ["^internal;openslide;openslide\.level\["]
-hide_metadata_keys_format_aperio = [
-    "^internal;openslide;(openslide\.comment|tiff\.ImageDescription)$",
-    "^internal;openslide;aperio\.(Original(Height|Width)|Left|Top|Right|Bottom|LineArea(X|Y)Offset|LineCameraSkew|Focus Offset|StripeWidth|DisplayColor)"]
-hide_metadata_keys_format_hamamatsu = ["^internal;openslide;hamamatsu\.((AHEX|MHLN|YRNP|zCoarse|zFine)\[|(X|Y)OffsetFromSlideCentre|ccd.(width|height)|(focalplane|slant)\.(left|right)(top|bottom)|stage.center)"]
-hide_metadata_keys_format_philips = []
+no_redact_control_keys = {
+    "^internal;aperio_version$": "",
+    "^internal;openslide;openslide\.(?!comment$)": "",
+    "^internal;openslide;tiff\.(ResolutionUnit|XResolution|YResolution)$": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$",
+    "^internal;openslide;tiff\.ResolutionUnit": ""}
+no_redact_control_keys_format_aperio = {
+    "^internal;openslide;aperio\.(AppMag|MPP|Exposure (Time|Scale))$": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$"}
+no_redact_control_keys_format_hamamatsu = {
+    "^internal;openslide;hamamatsu\.SourceLens$": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$"}
+no_redact_control_keys_format_philips = {}
+hide_metadata_keys = {
+    "^internal;openslide;openslide\.level\[": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$"}
+hide_metadata_keys_format_aperio = {
+    "^internal;openslide;(openslide\.comment|tiff\.ImageDescription)$": "",
+    "^internal;openslide;aperio\.(Original(Height|Width)|Left|Top|Right|Bottom|LineArea(X|Y)Offset|LineCameraSkew|Focus Offset|StripeWidth|DisplayColor)": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$"}
+hide_metadata_keys_format_hamamatsu = {
+    "^internal;openslide;hamamatsu\.((AHEX|MHLN|YRNP|zCoarse|zFine)\[|(X|Y)OffsetFromSlideCentre|ccd.(width|height)|(focalplane|slant)\.(left|right)(top|bottom)|stage.center)": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$"}
+hide_metadata_keys_format_philips = {}

--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -7,8 +7,8 @@ See the files ``devops/wsi_deid/docker-compose.example.local.yml`` and ``devops/
 
 When modifying ``devops/wsi_deid/girder.local.conf``, you'll also need to enable using the custom file by uncommenting a few lines as described in ``devops/wsi_deid/docker-compose.example.local.yml``.
 
-Settings in girder.local.cfg
-----------------------------
+Settings in girder.local.conf
+-----------------------------
 
 The WSI DeID specific settings are in a section headed by ``[wsi_deid]``.
 
@@ -20,9 +20,31 @@ When the ``redact_macro_square`` setting is set to ``True``, the upper left squa
 Redaction Catgories
 +++++++++++++++++++
 
-By default, when metadata or images are redacted, the user must pick the typoe of PHI/PII that is present and the reason for the redaction.  If the ``require_redact_category`` is set to ``False``, then, instead of requiring a reason, the user interface will show a ``REDACT`` button that toggles redaction on and off for the metadata or image.  The export file will contain ``No Reason Collected`` in these cases.
+By default, when metadata or images are redacted, the user must pick the type of PHI/PII that is present and the reason for the redaction.  If the ``require_redact_category`` is set to ``False``, then, instead of requiring a reason, the user interface will show a ``REDACT`` button that toggles redaction on and off for the metadata or image.  The export file will contain ``No Reason Collected`` in these cases.
 
 Redacting the Label Image
 +++++++++++++++++++++++++
 
-The label image can be redacted by default if the ``always_redact_label`` value is set to ``True``.  If the label image is redacted, it is repalced with a black square with the output filename printed in it.  The label image is not redacted, the output filename is added to the top of the image.
+The label image can be redacted by default if the ``always_redact_label`` value is set to ``True``.  If the label image is redacted, it is replaced with a black square with the output filename printed in it.  The label image is not redacted, the output filename is added to the top of the image.
+
+Disabling the Redaction Control
++++++++++++++++++++++++++++++++
+
+Redaction can be disabled for certain metadata fields. This can be used for fields that are helpful to users reviewing images, but will never contain actual PHI/PII. This can be configured on a per-format basis. In order to specify which fields should have redaction disabled, add those fields, as regular expressions, to the following lists:
+
+* ``no_redact_control_keys``
+* ``no_redact_control_keys_format_aperio``
+* ``no_redact_control_keys_format_hamamatsu``
+* ``no_redact_control_keys_format_philips``
+
+Note that fields specified in ``no_redact_control_keys`` will have redaction disabled on all image formats. If you wish to disable redaction of a metadata field on, for example, Aperio images only, you can add that value to the ``no_redact_control_keys_format_aperio`` list.
+
+Hiding Metadata Fields
+++++++++++++++++++++++
+
+If you wish to hide certain metadata fields because they will never contain PHI/PII and are not useful to reviewers, you can specify those metadata fields, as regular expressions, in the following lists in ``girder.local.conf``:
+
+* ``hide_metadata_keys``
+* ``hide_metadata_keys_format_aperio``
+* ``hide_metadata_keys_format_hamamatsu``
+* ``hide_metadata_keys_format_philips``

--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -30,21 +30,25 @@ The label image can be redacted by default if the ``always_redact_label`` value 
 Disabling the Redaction Control
 +++++++++++++++++++++++++++++++
 
-Redaction can be disabled for certain metadata fields. This can be used for fields that are helpful to users reviewing images, but will never contain actual PHI/PII. This can be configured on a per-format basis. In order to specify which fields should have redaction disabled, add those fields, as regular expressions, to the following lists:
+Redaction can be disabled for certain metadata fields. This can be used for fields that are helpful to users reviewing images, but will never contain actual PHI/PII. This can be configured on a per-format basis. The following settings control this functionality.
 
 * ``no_redact_control_keys``
 * ``no_redact_control_keys_format_aperio``
 * ``no_redact_control_keys_format_hamamatsu``
 * ``no_redact_control_keys_format_philips``
 
-Note that fields specified in ``no_redact_control_keys`` will have redaction disabled on all image formats. If you wish to disable redaction of a metadata field on, for example, Aperio images only, you can add that value to the ``no_redact_control_keys_format_aperio`` list.
+In order to disable redaction controls for certain metadata fields, you can add `key: value` pairs to the dictionaries in `girder.local.conf`. Both the key and value need to be regular expressions. The `key` is a regular expression that will match your target metadata. The associated `value` should be a regular expression that matches the expected metadata value. For example, if your metadata should always contain an integer value, you could use the regular expression `"\\d+"`. If you view an image and the metadata value does not match the expected expression, then redaction will be available for that metadata item.
+
+Note that fields specified in ``no_redact_control_keys`` will have redaction disabled on all image formats. If you wish to disable redaction of a metadata field on, for example, Aperio images only, you can add that metadata key and expected value to the ``no_redact_control_keys_format_aperio`` dictionary.
 
 Hiding Metadata Fields
 ++++++++++++++++++++++
 
-If you wish to hide certain metadata fields because they will never contain PHI/PII and are not useful to reviewers, you can specify those metadata fields, as regular expressions, in the following lists in ``girder.local.conf``:
+Similar to configuration for disabling redaction, if you wish to hide certain metadata fields because they will never contain PHI/PII and are not useful to reviewers, you can specify those metadata fields and their expected values, as regular expressions, in the following dictionaries in ``girder.local.conf``:
 
 * ``hide_metadata_keys``
 * ``hide_metadata_keys_format_aperio``
 * ``hide_metadata_keys_format_hamamatsu``
 * ``hide_metadata_keys_format_philips``
+
+If these metadata items contain unexpected values (e.g., text where a number was expected), they will be visible and available for redaction.

--- a/wsi_deid/config.py
+++ b/wsi_deid/config.py
@@ -1,7 +1,10 @@
 import girder.utility.config
 
 CONFIG_SECTION = 'wsi_deid'
-NUMERIC_VALUES = r'^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$'
+NUMERIC_VALUES = (
+    r'^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?'
+    r'(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$'
+)
 
 defaultConfig = {
     'redact_macro_square': False,

--- a/wsi_deid/config.py
+++ b/wsi_deid/config.py
@@ -10,22 +10,26 @@ defaultConfig = {
     'show_import_button': True,
     'show_export_button': True,
     'show_next_item': True,
-    'disable_redaction_for_metadata': [
+    'no_redact_control_keys': [
         r'^internal;aperio_version$',
         r'^internal;openslide;openslide\.(?!comment$)',
         r'^internal;openslide;tiff.(ResolutionUnit|XResolution|YResolution)$',
     ],
-    'disable_redaction_for_metadata_format_aperio': [],
-    'disable_redaction_for_metadata_format_hamamatsu': [],
-    'disable_redaction_for_metadata_format_philips': [],
-    'hide_metadata': [
+    'no_redact_control_keys_format_aperio': [
+        r'^internal;openslide;aperio.AppMag',
+    ],
+    'no_redact_control_keys_format_hamamatsu': [],
+    'no_redact_control_keys_format_philips': [],
+    'hide_metadata_keys': [
         r'^internal;openslide;openslide.level\[',
-        r'^internal;openslide;hamamatsu.(AHEX|MHLN)\[',
+    ],
+    'hide_metadata_keys_format_aperio': [
         r'^internal;openslide;(openslide.comment|tiff.ImageDescription)$',
     ],
-    'hide_metadata_format_aperio': [],
-    'hide_metadata_format_hamamatsu': [],
-    'hide_metadata_format_philips': [],
+    'hide_metadata_keys_format_hamamatsu': [
+        r'^internal;openslide;hamamatsu.(AHEX|MHLN)\[',
+    ],
+    'hide_metadata_keys_format_philips': [],
 }
 
 

--- a/wsi_deid/config.py
+++ b/wsi_deid/config.py
@@ -12,7 +12,7 @@ defaultConfig = {
     'show_next_item': True,
     'disable_redaction_for_metadata': [
         r'^internal;aperio_version$',
-        r'internal;openslide;openslide\.(?!comments$)',
+        r'^internal;openslide;openslide\.(?!comment$)',
         r'^internal;openslide;tiff.(ResolutionUnit|XResolution|YResolution)$',
     ],
     'disable_redaction_for_metadata_format_aperio': [],

--- a/wsi_deid/config.py
+++ b/wsi_deid/config.py
@@ -1,6 +1,7 @@
 import girder.utility.config
 
 CONFIG_SECTION = 'wsi_deid'
+NUMERIC_VALUES = r'^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$'
 
 defaultConfig = {
     'redact_macro_square': False,
@@ -10,36 +11,37 @@ defaultConfig = {
     'show_import_button': True,
     'show_export_button': True,
     'show_next_item': True,
-    'no_redact_control_keys': [
-        r'^internal;aperio_version$',
-        r'^internal;openslide;openslide\.(?!comment$)',
-        r'^internal;openslide;tiff\.(ResolutionUnit|XResolution|YResolution)$',
-    ],
-    'no_redact_control_keys_format_aperio': [
-        r'^internal;openslide;aperio\.(AppMag|MPP|Exposure (Time|Scale))$',
-    ],
-    'no_redact_control_keys_format_hamamatsu': [
-        r'^internal;openslide;hamamatsu\.SourceLens$',
-    ],
-    'no_redact_control_keys_format_philips': [],
-    'hide_metadata_keys': [
-        r'^internal;openslide;openslide\.level\[',
-    ],
-    'hide_metadata_keys_format_aperio': [
-        r'^internal;openslide;(openslide\.comment|tiff\.ImageDescription)$',
+    'no_redact_control_keys': {
+        r'^internal;aperio_version$': '',
+        r'^internal;openslide;openslide\.(?!comment$)': '',
+        r'^internal;openslide;tiff\.(XResolution|YResolution)$': NUMERIC_VALUES,
+        r'^internal;openslide;tiff\.ResolutionUnit$': '',
+    },
+    'no_redact_control_keys_format_aperio': {
+        r'^internal;openslide;aperio\.(AppMag|MPP|Exposure (Time|Scale))$': NUMERIC_VALUES,
+    },
+    'no_redact_control_keys_format_hamamatsu': {
+        r'^internal;openslide;hamamatsu\.SourceLens$': NUMERIC_VALUES,
+    },
+    'no_redact_control_keys_format_philips': {},
+    'hide_metadata_keys': {
+        r'^internal;openslide;openslide\.level\[': NUMERIC_VALUES,
+    },
+    'hide_metadata_keys_format_aperio': {
+        r'^internal;openslide;(openslide\.comment|tiff\.ImageDescription)$': '',
         (
             r'^internal;openslide;aperio\.(Original(Height|Width)|Left|Top|Right|Bottom'
             r'|LineArea(X|Y)Offset|LineCameraSkew|Focus Offset|StripeWidth|DisplayColor)'
-        ),
-    ],
-    'hide_metadata_keys_format_hamamatsu': [
+        ): NUMERIC_VALUES,
+    },
+    'hide_metadata_keys_format_hamamatsu': {
         (
             r'^internal;openslide;hamamatsu\.((AHEX|MHLN|YRNP|zCoarse|zFine)\['
             r'|(X|Y)OffsetFromSlideCentre|ccd.(width|height)|(focalplane|slant)\.(left|right)'
             r'(top|bottom)|stage.center)'
-        ),
-    ],
-    'hide_metadata_keys_format_philips': [],
+        ): NUMERIC_VALUES,
+    },
+    'hide_metadata_keys_format_philips': {},
 }
 
 

--- a/wsi_deid/config.py
+++ b/wsi_deid/config.py
@@ -10,6 +10,22 @@ defaultConfig = {
     'show_import_button': True,
     'show_export_button': True,
     'show_next_item': True,
+    'disable_redaction_for_metadata': [
+        r'^internal;aperio_version$',
+        r'internal;openslide;openslide\.(?!comments$)',
+        r'^internal;openslide;tiff.(ResolutionUnit|XResolution|YResolution)$',
+    ],
+    'disable_redaction_for_metadata_format_aperio': [],
+    'disable_redaction_for_metadata_format_hamamatsu': [],
+    'disable_redaction_for_metadata_format_philips': [],
+    'hide_metadata': [
+        r'^internal;openslide;openslide.level\[',
+        r'^internal;openslide;hamamatsu.(AHEX|MHLN)\[',
+        r'^internal;openslide;(openslide.comment|tiff.ImageDescription)$',
+    ],
+    'hide_metadata_format_aperio': [],
+    'hide_metadata_format_hamamatsu': [],
+    'hide_metadata_format_philips': [],
 }
 
 

--- a/wsi_deid/config.py
+++ b/wsi_deid/config.py
@@ -29,7 +29,7 @@ defaultConfig = {
         r'^internal;openslide;(openslide\.comment|tiff\.ImageDescription)$',
         (
             r'^internal;openslide;aperio\.(Original(Height|Width)|Left|Top|Right|Bottom'
-            r'|LineArea(X|Y)Offset|LineCameraSkew|Focus Offset|StripeWidth)'
+            r'|LineArea(X|Y)Offset|LineCameraSkew|Focus Offset|StripeWidth|DisplayColor)'
         ),
     ],
     'hide_metadata_keys_format_hamamatsu': [

--- a/wsi_deid/config.py
+++ b/wsi_deid/config.py
@@ -13,21 +13,31 @@ defaultConfig = {
     'no_redact_control_keys': [
         r'^internal;aperio_version$',
         r'^internal;openslide;openslide\.(?!comment$)',
-        r'^internal;openslide;tiff.(ResolutionUnit|XResolution|YResolution)$',
+        r'^internal;openslide;tiff\.(ResolutionUnit|XResolution|YResolution)$',
     ],
     'no_redact_control_keys_format_aperio': [
-        r'^internal;openslide;aperio.AppMag',
+        r'^internal;openslide;aperio\.(AppMag|MPP|Exposure (Time|Scale))$',
     ],
-    'no_redact_control_keys_format_hamamatsu': [],
+    'no_redact_control_keys_format_hamamatsu': [
+        r'^internal;openslide;hamamatsu\.SourceLens$',
+    ],
     'no_redact_control_keys_format_philips': [],
     'hide_metadata_keys': [
-        r'^internal;openslide;openslide.level\[',
+        r'^internal;openslide;openslide\.level\[',
     ],
     'hide_metadata_keys_format_aperio': [
-        r'^internal;openslide;(openslide.comment|tiff.ImageDescription)$',
+        r'^internal;openslide;(openslide\.comment|tiff\.ImageDescription)$',
+        (
+            r'^internal;openslide;aperio\.(Original(Height|Width)|Left|Top|Right|Bottom'
+            r'|LineArea(X|Y)Offset|LineCameraSkew|Focus Offset|StripeWidth)'
+        ),
     ],
     'hide_metadata_keys_format_hamamatsu': [
-        r'^internal;openslide;hamamatsu.(AHEX|MHLN)\[',
+        (
+            r'^internal;openslide;hamamatsu\.((AHEX|MHLN|YRNP|zCoarse|zFine)\['
+            r'|(X|Y)OffsetFromSlideCentre|ccd.(width|height)|(focalplane|slant)\.(left|right)'
+            r'(top|bottom)|stage.center)'
+        ),
     ],
     'hide_metadata_keys_format_philips': [],
 }

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -123,8 +123,8 @@ wrap(ItemView, 'render', function (render) {
 
     const isValidRegex = (string) => {
         try {
-            const regExp = new RegExp(string);
-        } catch(e) {
+            void new RegExp(string);
+        } catch (e) {
             console.error(`There was an error parsing "${string}" as a regular expression: ${e}.`);
             return false;
         }
@@ -133,22 +133,8 @@ wrap(ItemView, 'render', function (render) {
 
     const validateRedactionPatternObject = (redactionPatterns) => {
         for (const key in redactionPatterns) {
-            let removeKey = false;
-            try {
-                new RegExp(key);
-            } catch (e) {
-                removeKey = true;
-                console.error(`There was an error parsing "${key}" as a regular expression: ${e}.`);
-            }
-            let value = redactionPatterns[key];
-            try {
-                new RegExp(value);
-            } catch (e) {
-                removeKey = true;
-                console.error(`There was an error parsing "${value}" as a regular expression: ${e}.`);
-            }
-            if (removeKey) {
-                delete redactionPatterns[key]
+            if (!isValidRegex(key) || !isValidRegex(redactionPatterns[key])) {
+                delete redactionPatterns[key];
             }
         }
         return redactionPatterns;

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -110,9 +110,9 @@ wrap(ItemView, 'render', function (render) {
     };
 
     const getFormat = () => {
-        if (this.$el.find('.large_image_metadata_value[keyname^="internal;openslide;aperio."]').length > 0) {
+        if (this.$el.find('.large_image_metadata_value[keyname^="internal;openslide;openslide.vendor"]').text() === 'aperio') {
             return formats.aperio;
-        } else if (this.$el.find('.large_image_metadata_value[keyname^="internal;openslide;hamamatsu."]').length > 0) {
+        } else if (this.$el.find('.large_image_metadata_value[keyname^="internal;openslide;openslide.vendor"]').text() === 'hamamatsu') {
             return formats.hamamatsu;
         } else if (this.$el.find('.large_image_metadata_value[keyname^="internal;xml;PIM_DP_"]').length > 0) {
             return formats.philips;

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -159,8 +159,8 @@ wrap(ItemView, 'render', function (render) {
         return patterns;
     };
 
-    const showRedactButton = (keyname, redactionDisabledPatterns) => {
-        for (const pattern of redactionDisabledPatterns) {
+    const showRedactButton = (keyname, disableRedactionPatterns) => {
+        for (const pattern of disableRedactionPatterns) {
             if (keyname.match(new RegExp(pattern))) {
                 return false;
             }
@@ -266,7 +266,7 @@ wrap(ItemView, 'render', function (render) {
         this.$el.find('.li-metadata-tabs .tab-pane').last().addClass('active');
 
         const redactList = this.getRedactList();
-        const redactionDiabledPatterns = getRedactionDisabledPatterns(settings);
+        const disableRedactionPatterns = getRedactionDisabledPatterns(settings);
         const hideFieldPatterns = getHiddenMetadataPatterns(settings);
         // Add redaction controls to metadata
         this.$el.find('table[keyname="internal"] .large_image_metadata_value').each((idx, elem) => {
@@ -283,7 +283,7 @@ wrap(ItemView, 'render', function (render) {
                     elem.append($('<span class="redact-replacement"/>').text(redactList.metadata[keyname].value));
                     redactButtonAllowed = false;
                 }
-                if (showRedactButton(keyname, redactionDiabledPatterns) && redactButtonAllowed) {
+                if (showRedactButton(keyname, disableRedactionPatterns) && redactButtonAllowed) {
                     addRedactButton(elem, keyname, redactList.metadata[keyname], 'metadata', settings);
                 }
                 elem.toggleClass('redacted', isRedacted);

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -123,16 +123,16 @@ wrap(ItemView, 'render', function (render) {
 
     const getRedactionDisabledPatterns = (settings) => {
         const format = getFormat();
-        let patterns = settings.disable_redaction_for_metadata;
+        let patterns = settings.no_redact_control_keys;
         switch (format) {
             case formats.aperio:
-                patterns = patterns.concat(settings.disable_redaction_for_metadata_format_aperio);
+                patterns = patterns.concat(settings.no_redact_control_keys_format_aperio);
                 break;
             case formats.hamamatsu:
-                patterns = patterns.concat(settings.disable_redaction_for_metadata_format_hamamatsu);
+                patterns = patterns.concat(settings.no_redact_control_keys_format_hamamatsu);
                 break;
             case formats.philips:
-                patterns = patterns.concat(settings.disable_redaction_for_metadata_format_philips);
+                patterns = patterns.concat(settings.no_redact_control_keys_format_philips);
                 break;
             default:
                 break;
@@ -142,16 +142,16 @@ wrap(ItemView, 'render', function (render) {
 
     const getHiddenMetadataPatterns = (settings) => {
         const format = getFormat();
-        let patterns = settings.hide_metadata;
+        let patterns = settings.hide_metadata_keys;
         switch (format) {
             case formats.aperio:
-                patterns = patterns.concat(settings.hide_metadata_format_aperio);
+                patterns = patterns.concat(settings.hide_metadata_keys_format_aperio);
                 break;
             case formats.hamamatsu:
-                patterns = patterns.concat(settings.hide_metadata_format_hamamatsu);
+                patterns = patterns.concat(settings.hide_metadata_keys_format_hamamatsu);
                 break;
             case formats.philips:
-                patterns = patterns.concat(settings.hide_metadata_format_philips);
+                patterns = patterns.concat(settings.hide_metadata_keys_format_philips);
                 break;
             default:
                 break;

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -121,6 +121,16 @@ wrap(ItemView, 'render', function (render) {
         }
     };
 
+    const isValidRegex = (string) => {
+        try {
+            const regExp = new RegExp(string);
+        } catch(e) {
+            console.error(`There was an error parsing "${string}" as a regular expression: ${e}.`);
+            return false;
+        }
+        return true;
+    };
+
     const getRedactionDisabledPatterns = (settings) => {
         const format = getFormat();
         let patterns = settings.no_redact_control_keys;
@@ -137,7 +147,7 @@ wrap(ItemView, 'render', function (render) {
             default:
                 break;
         }
-        return patterns;
+        return patterns.filter(pattern => isValidRegex(pattern));
     };
 
     const getHiddenMetadataPatterns = (settings) => {
@@ -156,7 +166,7 @@ wrap(ItemView, 'render', function (render) {
             default:
                 break;
         }
-        return patterns;
+        return patterns.filter(pattern => isValidRegex(pattern));
     };
 
     const showRedactButton = (keyname, disableRedactionPatterns) => {

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -143,38 +143,14 @@ wrap(ItemView, 'render', function (render) {
     const getRedactionDisabledPatterns = (settings) => {
         const format = getFormat();
         let patterns = settings.no_redact_control_keys; // patterns is an object that looks like {key:value}, where `key` and `value` are both regular expressions
-        switch (format) {
-            case formats.aperio:
-                patterns = Object.assign(patterns, patterns, settings.no_redact_control_keys_format_aperio);
-                break;
-            case formats.hamamatsu:
-                patterns = Object.assign(patterns, patterns, settings.no_redact_control_keys_format_hamamatsu);
-                break;
-            case formats.philips:
-                patterns = Object.assign(patterns, patterns, settings.no_redact_control_keys_format_philips);
-                break;
-            default:
-                break;
-        }
+        patterns = Object.assign({}, patterns, settings['no_redact_control_keys_format_' + format] || {});
         return validateRedactionPatternObject(patterns);
     };
 
     const getHiddenMetadataPatterns = (settings) => {
         const format = getFormat();
         let patterns = settings.hide_metadata_keys;
-        switch (format) {
-            case formats.aperio:
-                patterns = Object.assign(patterns, patterns, settings.hide_metadata_keys_format_aperio);
-                break;
-            case formats.hamamatsu:
-                patterns = Object.assign(patterns, patterns, settings.hide_metadata_keys_format_hamamatsu);
-                break;
-            case formats.philips:
-                patterns = Object.assign(patterns, patterns, settings.hide_metadata_keys_format_philips);
-                break;
-            default:
-                break;
-        }
+        patterns = Object.assign({}, patterns, settings['hide_metadata_keys_format_' + format] || {});
         return validateRedactionPatternObject(patterns);
     };
 

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -42,8 +42,8 @@ const formats = {
     aperio: 'aperio',
     hamamatsu: 'hamamatsu',
     philips: 'philips',
-    none: '',
-}
+    none: ''
+};
 
 wrap(ItemView, 'render', function (render) {
     this.getRedactList = () => {
@@ -133,6 +133,7 @@ wrap(ItemView, 'render', function (render) {
                 break;
             case formats.philips:
                 patterns = patterns.concat(settings.disable_redaction_for_metadata_format_philips);
+                break;
             default:
                 break;
         }
@@ -151,21 +152,18 @@ wrap(ItemView, 'render', function (render) {
                 break;
             case formats.philips:
                 patterns = patterns.concat(settings.hide_metadata_format_philips);
+                break;
             default:
                 break;
         }
         return patterns;
     };
 
-    const showRedactButton = (keyname) => {
-        if (keyname.match(/^internal;aperio_version$/)) {
-            return false;
-        }
-        if (keyname.match(/^internal;openslide;openslide\.(?!comment$)/)) {
-            return false;
-        }
-        if (keyname.match(/^internal;openslide;tiff.(ResolutionUnit|XResolution|YResolution)$/)) {
-            return false;
+    const showRedactButton = (keyname, redactionDisabledPatterns) => {
+        for (const pattern of redactionDisabledPatterns) {
+            if (keyname.match(new RegExp(pattern))) {
+                return false;
+            }
         }
         return true;
     };
@@ -218,16 +216,11 @@ wrap(ItemView, 'render', function (render) {
         parentElem.append(elem);
     };
 
-    const hideField = (keyname) => {
-        const isAperio = this.$el.find('.large_image_metadata_value[keyname^="internal;openslide;aperio."]').length > 0;
-        if (isAperio && keyname.match(/^internal;openslide;(openslide.comment|tiff.ImageDescription)$/)) {
-            return true;
-        }
-        if (keyname.match(/^internal;openslide;openslide.level\[/)) {
-            return true;
-        }
-        if (keyname.match(/^internal;openslide;hamamatsu.(AHEX|MHLN)\[/)) {
-            return true;
+    const hideField = (keyname, hideFieldPatterns) => {
+        for (const pattern of hideFieldPatterns) {
+            if (keyname.match(new RegExp(pattern))) {
+                return true;
+            }
         }
         return false;
     };
@@ -273,8 +266,8 @@ wrap(ItemView, 'render', function (render) {
         this.$el.find('.li-metadata-tabs .tab-pane').last().addClass('active');
 
         const redactList = this.getRedactList();
-        const redactionDiabledPatterns = getRedactionDisabledPatterns();
-        const hideFieldPatterns = getHiddenMetadataPatterns();
+        const redactionDiabledPatterns = getRedactionDisabledPatterns(settings);
+        const hideFieldPatterns = getHiddenMetadataPatterns(settings);
         // Add redaction controls to metadata
         this.$el.find('table[keyname="internal"] .large_image_metadata_value').each((idx, elem) => {
             elem = $(elem);


### PR DESCRIPTION
Closes #203 
This changes how `ItemView.js::showRedactButton` and `ItemView.js::hideField` work. Instead of hard-coding regular expressions in these functions to disable redaction or hide metadata fields, respectively, regular expressions are now pulled down from the girder configuration. 

New settings have been added under `[wsi_deid]` in `girder.local.conf`, which contain the default values previously coded into the functions mentioned above.

In order to specify metadata fields for which redaction should be disabled, regular expressions that those fields will match should be added to the settings starting with `no_redact_control_keys`. One is a catch-all, which will apply to all images, and the other three only apply to one format.

In order to hide metadata fields, modify settings starting with `hide_metadata_keys` in the same way.

Part of this change should include adding default values to these settings, beyond the few that already exist.

Reviewers: Please give thoughts on the following fields in regards to including them as defaults to disable/hide.

**Openslide**
- `openslide.mpp-x`
- `openslide.mpp-y`
These values are somewhat redundant. Aperio consolidates these values into `aperio.MPP`, and these values can be calculated from `philips.DICOM_PIXEL_SPACING` and `hamamatsu.XResolution` (for .ndpi) or `hamamatsu.PhysicalWidth` (for .vsm). These can likely be hidden, and the format-specific values should be non-redactable (this is already the case for Hamamatsu).

**Aperio:**

- `aperio.Top`
- `aperio.Right`
- `aperio.Bottom`
- `aperio.Left`
- `aperio.DisplayColor`
- `aperio.Exposure Scale`
- `aperio.Exposure Time`
- `aperio.Focus Offset`
- `aperio.LineAreaXOffset`
- `aperio.LineAreaYOffset`
- `aperio.LineCameraSkew`
- `aperio.OriginalHeight`
- `aperio.OriginalWidth`
- `aperio.StripeWidth`
These fields are numeric, and related to more technical details about the image itself, and therefore highly unlikely to contain redactable information. Further, this information is unlikely to be useful, and some of these fields may be incorrect, according to [openslide.org](https://openslide.org/docs/properties/). These could be good candidates for metadata fields to hide altogether.

**Hamamatsu**

- `hamamatsu.SourceLens`
This field should be visible but not redactable. It is derived from `openslide.objective-power`, same as `aperio.AppMag`.

- `hamamatsu.XOffsetFromSlideCentre`
- `hamamatsu.YOffsetFromSlideCentre`
- `hamamatsu.ccd.<height, width>`
- `hamamatsu.focalplane.*`
- `hamamatsu.slant.*`
- `hamamatsu.zCourse[0, 1, 2]`
- `hamamatsu.zFine[0, 1, 2]`
These fields, similar to the ones specified under **Aperio** appear to be numeric, and describe attributes of the position of the slide when the image was taken. These may be worth hiding, since they likely don't contain PHI/PII.

**Philips**
For similar reasons to the other vendors, the following metadata fields for Philips-formatted images might be good candidates to hide from end users.
- `PIIM_DP_SCANNER_RACK_NUMBER`
- `PIIM_DP_SCANNER_SLOT_NUMBER`
- `PIIM_DP_SCANNED_IMAGES|DICOM_BITS_ALLOWED`
- `PIIM_DP_SCANNED_IMAGES|DICOM_DERIVATION_DESCRIPTION`
- `PIM_DP_SCANNED_IMAGES|DICOM_HIGH_BIT`
- `PIM_DP_SCANNED_IMAGES|DICOM_PLANAR_CONFIGURATION`
- `PIM_DP_SCANNED_IMAGES|DICOM_SAMPLES_PER_PIXEL`
- `PIM_DP_SCANNED_IMAGES|PIIM_PIXEL_DATA_REPRESENTATION_SEQUENCE|PIIM_PIXEL_DATA_REPRESENTATION_<COLUMNS/NUMBER/ROWS>`
- `PIM_DP_SCANNED_IMAGES|PIM_DP_IMAGE_<COLUMNS/ROWS>`
- `PIM_DP_SCANNER_RACK_PRIORITY`
- `PIM_DP_UFS_INTERFACE_VERSION`
