### PR TITLE
Add textbox for editing redacted metadata

### DIFF
--- a/devops/wsi_deid/girder.local.conf
+++ b/devops/wsi_deid/girder.local.conf
@@ -24,6 +24,7 @@ enabled = True
 [wsi_deid]
 redact_macro_square = False
 always_redact_label = False
+edit_metadata = False
 require_redact_category = True
 no_redact_control_keys = {
     "^internal;aperio_version$": "",

--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -17,8 +17,8 @@ Redacting the top/left of the macro image
 
 When the ``redact_macro_square`` setting is set to ``True``, the upper left square of all macro images will automatically be blacked out.  This region often contains the label on the slide, and sometimes that can contain PHI that is visible with contrast or other image adjustment.
 
-Redaction Catgories
-+++++++++++++++++++
+Redaction Categories
+++++++++++++++++++++
 
 By default, when metadata or images are redacted, the user must pick the type of PHI/PII that is present and the reason for the redaction.  If the ``require_redact_category`` is set to ``False``, then, instead of requiring a reason, the user interface will show a ``REDACT`` button that toggles redaction on and off for the metadata or image.  The export file will contain ``No Reason Collected`` in these cases.
 
@@ -52,3 +52,8 @@ Similar to configuration for disabling redaction, if you wish to hide certain me
 * ``hide_metadata_keys_format_philips``
 
 If these metadata items contain unexpected values (e.g., text where a number was expected), they will be visible and available for redaction.
+
+Editing Metadata Values
++++++++++++++++++++++++
+
+Normally, when a metadata field is redacted, its value becomes blank. In `girder.local.conf`, you can set `edit_metadata` to `True` to enable editing metadata as part of the redaction process. If editing metadata is enabled, users will have the opportunity to set the value of a redacted metadata field to any value.

--- a/docs/USAGE.rst
+++ b/docs/USAGE.rst
@@ -276,6 +276,8 @@ Review Process for PHI/PII in Image(s) and Metadata
 
    The user can view metadata fields, and if any of these contain PHI/PII, the user should select the classification of PHI in the redact control for that field (see the PHI/PII Definitions and Types, below). The metadata field will then have a line through the text, indicating that the field will be redacted (it has been marked for redaction).
 
+   If editing metadata is enabled (see `CUSTOMIZING.rst <CUSTOMIZING.rst>`_ for details turning this on), a text box will appear next to any metadata field that has been marked for redaction. Users can type a new value into this field, to replace the redacted value. This text box only appears if a metadata field is marked for redaction.
+
    2.3. Scroll down to the bottom of the screen and review the associated images (label, macro, and thumbnail).  If you see PHI/PII in individual associated images, select the classification of PHI in the image from the redact control. The image will show an X through it to indicate that it will be redacted.
 
    2.4. When redaction decisions have been made for all images and metadata, the user should click the ``Redact Image`` button, which will make a copy of the existing image and place that copy in the ``Original`` folder, and will move the image to the ``Redacted`` folder. As part of moving the data to the ``Redacted`` folder, the metadata fields and associated images that have been marked for redaction will be deleted.

--- a/wsi_deid/config.py
+++ b/wsi_deid/config.py
@@ -10,6 +10,7 @@ defaultConfig = {
     'redact_macro_square': False,
     'always_redact_label': False,
     'require_redact_category': True,
+    'edit_meatadata': False,
     'add_title_to_label': True,
     'show_import_button': True,
     'show_export_button': True,

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -110,7 +110,9 @@ def get_standard_redactions(item, title):
                 value = value[:5] + '01:01' + value[10:]
             else:
                 value = None
-            redactList['metadata']['internal;openslide;tiff.%s' % key] = generate_system_redaction_list_entry(value)
+            redactList['metadata']['internal;openslide;tiff.%s' % key] = (
+                generate_system_redaction_list_entry(value)
+            )
     # Make, Model, Software?
     for key in {'Copyright', 'HostComputer'}:
         tag = tifftools.Tag[key].value
@@ -122,19 +124,22 @@ def get_standard_redactions(item, title):
 
 def get_standard_redactions_format_aperio(item, tileSource, tiffinfo, title):
     metadata = tileSource.getInternalMetadata() or {}
+    title_redaction_list_entry = generate_system_redaction_list_entry(title)
     redactList = {
         'images': {},
         'metadata': {
-            'internal;openslide;aperio.Filename': generate_system_redaction_list_entry(title),
-            'internal;openslide;aperio.Title': generate_system_redaction_list_entry(title),
+            'internal;openslide;aperio.Filename': title_redaction_list_entry,
+            'internal;openslide;aperio.Title': title_redaction_list_entry,
             'internal;openslide;tiff.Software': generate_system_redaction_list_entry(
                 get_deid_field(item, metadata.get('openslide', {}).get('tiff.Software'))
             ),
         },
     }
     if metadata['openslide'].get('aperio.Date'):
-        redactList['metadata']['internal;openslide;aperio.Date'] = generate_system_redaction_list_entry(
-            '01/01/' + metadata['openslide']['aperio.Date'][6:]
+        redactList['metadata']['internal;openslide;aperio.Date'] = (
+            generate_system_redaction_list_entry(
+                '01/01/' + metadata['openslide']['aperio.Date'][6:]
+            )
         )
     return redactList
 
@@ -176,7 +181,9 @@ def get_standard_redactions_format_philips(item, tileSource, tiffinfo, title):
                 value = None
             else:
                 value = value[:4] + '0101'
-            redactList['metadata']['internal;xml;%s' % key] = generate_system_redaction_list_entry(value)
+            redactList['metadata']['internal;xml;%s' % key] = (
+                generate_system_redaction_list_entry(value)
+            )
     for key in {'DICOM_ACQUISITION_DATETIME'}:
         if metadata['xml'].get(key):
             value = metadata['xml'][key].strip('"')
@@ -184,7 +191,9 @@ def get_standard_redactions_format_philips(item, tileSource, tiffinfo, title):
                 value = None
             else:
                 value = value[:4] + '0101' + value[8:]
-            redactList['metadata']['internal;xml;%s' % key] = generate_system_redaction_list_entry(value)
+            redactList['metadata']['internal;xml;%s' % key] = (
+                generate_system_redaction_list_entry(value)
+            )
     return redactList
 
 
@@ -739,8 +748,9 @@ def redact_format_philips(item, tempdir, redactList, title, labelImage, macroIma
                 'data', '').split()[0].lower() not in redactList['images']]
 
     redactList = copy.copy(redactList)
-    redactList['metadata']['internal;xml;PIIM_DP_SCANNER_OPERATOR_ID'] = generate_system_redaction_list_entry(title)
-    redactList['metadata']['internal;xml;PIM_DP_UFS_BARCODE'] = generate_system_redaction_list_entry(title)
+    title_redaction_list_entry = generate_system_redaction_list_entry(title)
+    redactList['metadata']['internal;xml;PIIM_DP_SCANNER_OPERATOR_ID'] = title_redaction_list_entry
+    redactList['metadata']['internal;xml;PIM_DP_UFS_BARCODE'] = title_redaction_list_entry
     # redact general tiff tags
     redact_tiff_tags(ifds, redactList, title)
     add_deid_metadata(item, ifds)

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -17,6 +17,14 @@ from large_image.tilesource import dictToEtree
 from . import config
 
 
+def generate_system_redaction_list_entry(newValue):
+    """Create an entry for the redaction list for a redaction performed by the system."""
+    return {
+        'value': newValue,
+        'reason': 'System Redacted',
+    }
+
+
 def get_redact_list(item):
     """
     Get the redaction list, ensuring that the images and metadata
@@ -102,7 +110,7 @@ def get_standard_redactions(item, title):
                 value = value[:5] + '01:01' + value[10:]
             else:
                 value = None
-            redactList['metadata']['internal;openslide;tiff.%s' % key] = {'value': value}
+            redactList['metadata']['internal;openslide;tiff.%s' % key] = generate_system_redaction_list_entry(value)
     # Make, Model, Software?
     for key in {'Copyright', 'HostComputer'}:
         tag = tifftools.Tag[key].value
@@ -117,15 +125,17 @@ def get_standard_redactions_format_aperio(item, tileSource, tiffinfo, title):
     redactList = {
         'images': {},
         'metadata': {
-            'internal;openslide;aperio.Filename': {'value': title},
-            'internal;openslide;aperio.Title': {'value': title},
-            'internal;openslide;tiff.Software': {
-                'value': get_deid_field(item, metadata.get('openslide', {}).get('tiff.Software'))},
+            'internal;openslide;aperio.Filename': generate_system_redaction_list_entry(title),
+            'internal;openslide;aperio.Title': generate_system_redaction_list_entry(title),
+            'internal;openslide;tiff.Software': generate_system_redaction_list_entry(
+                get_deid_field(item, metadata.get('openslide', {}).get('tiff.Software'))
+            ),
         },
     }
     if metadata['openslide'].get('aperio.Date'):
-        redactList['metadata']['internal;openslide;aperio.Date'] = {
-            'value': '01/01/' + metadata['openslide']['aperio.Date'][6:]}
+        redactList['metadata']['internal;openslide;aperio.Date'] = generate_system_redaction_list_entry(
+            '01/01/' + metadata['openslide']['aperio.Date'][6:]
+        )
     return redactList
 
 
@@ -134,9 +144,10 @@ def get_standard_redactions_format_hamamatsu(item, tileSource, tiffinfo, title):
     redactList = {
         'images': {},
         'metadata': {
-            'internal;openslide;hamamatsu.Reference': {'value': title},
-            'internal;openslide;tiff.Software': {
-                'value': get_deid_field(item, metadata.get('openslide', {}).get('tiff.Software'))},
+            'internal;openslide;hamamatsu.Reference': generate_system_redaction_list_entry(title),
+            'internal;openslide;tiff.Software': generate_system_redaction_list_entry(
+                get_deid_field(item, metadata.get('openslide', {}).get('tiff.Software'))
+            )
         },
     }
     for key in {'Created', 'Updated'}:
@@ -151,10 +162,11 @@ def get_standard_redactions_format_philips(item, tileSource, tiffinfo, title):
     redactList = {
         'images': {},
         'metadata': {
-            'internal;xml;PIIM_DP_SCANNER_OPERATOR_ID': {'value': title},
-            'internal;xml;PIM_DP_UFS_BARCODE': {'value': title},
-            'internal;tiff;software': {
-                'value': get_deid_field(item, metadata.get('tiff', {}).get('software'))},
+            'internal;xml;PIIM_DP_SCANNER_OPERATOR_ID': generate_system_redaction_list_entry(title),
+            'internal;xml;PIM_DP_UFS_BARCODE': generate_system_redaction_list_entry(title),
+            'internal;tiff;software': generate_system_redaction_list_entry(
+                get_deid_field(item, metadata.get('tiff', {}).get('software'))
+            ),
         },
     }
     for key in {'DICOM_DATE_OF_LAST_CALIBRATION'}:
@@ -164,7 +176,7 @@ def get_standard_redactions_format_philips(item, tileSource, tiffinfo, title):
                 value = None
             else:
                 value = value[:4] + '0101'
-            redactList['metadata']['internal;xml;%s' % key] = {'value': value}
+            redactList['metadata']['internal;xml;%s' % key] = generate_system_redaction_list_entry(value)
     for key in {'DICOM_ACQUISITION_DATETIME'}:
         if metadata['xml'].get(key):
             value = metadata['xml'][key].strip('"')
@@ -172,7 +184,7 @@ def get_standard_redactions_format_philips(item, tileSource, tiffinfo, title):
                 value = None
             else:
                 value = value[:4] + '0101' + value[8:]
-            redactList['metadata']['internal;xml;%s' % key] = {'value': value}
+            redactList['metadata']['internal;xml;%s' % key] = generate_system_redaction_list_entry(value)
     return redactList
 
 
@@ -727,8 +739,8 @@ def redact_format_philips(item, tempdir, redactList, title, labelImage, macroIma
                 'data', '').split()[0].lower() not in redactList['images']]
 
     redactList = copy.copy(redactList)
-    redactList['metadata']['internal;xml;PIIM_DP_SCANNER_OPERATOR_ID'] = {'value': title}
-    redactList['metadata']['internal;xml;PIM_DP_UFS_BARCODE'] = {'value': title}
+    redactList['metadata']['internal;xml;PIIM_DP_SCANNER_OPERATOR_ID'] = generate_system_redaction_list_entry(title)
+    redactList['metadata']['internal;xml;PIM_DP_UFS_BARCODE'] = generate_system_redaction_list_entry(title)
     # redact general tiff tags
     redact_tiff_tags(ifds, redactList, title)
     add_deid_metadata(item, ifds)

--- a/wsi_deid/web_client/stylesheets/ItemView.styl
+++ b/wsi_deid/web_client/stylesheets/ItemView.styl
@@ -1,13 +1,16 @@
-.g-hui-redact-label, a.g-hui-redact>span
+.g-hui-redact-label, .wsi-deid-replace-value, a.g-hui-redact>span, label
   text-transform uppercase
   font-weight bold
   font-size 12px
   margin-left 10px
   display inline-block
-  .g-hui-redact
+  .g-hui-redact, .wsi-deid-replace-value-input
     margin-left 5px
     font-weight normal
     text-transform none
+
+.wsi-deid-replace-value
+  display: none
 
 .large_image_metadata_value.redacted
   text-decoration-line line-through
@@ -19,6 +22,8 @@
     display inline-block
   .g-hui-redact-label
     text-decoration-line none
+  .wsi-deid-replace-value
+    display: inline-block
   a.g-hui-redact>span
     text-decoration-line line-through
 

--- a/wsi_deid/web_client/stylesheets/ItemView.styl
+++ b/wsi_deid/web_client/stylesheets/ItemView.styl
@@ -10,7 +10,7 @@
     text-transform none
 
 .wsi-deid-replace-value
-  display: none
+  display none
 
 .large_image_metadata_value.redacted
   text-decoration-line line-through
@@ -23,7 +23,7 @@
   .g-hui-redact-label
     text-decoration-line none
   .wsi-deid-replace-value
-    display: inline-block
+    display inline-block
   a.g-hui-redact>span
     text-decoration-line line-through
 

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -235,6 +235,10 @@ wrap(ItemView, 'render', function (render) {
     };
 
     const addNewValueEntryField = (parentElem, keyname, redactRecord, settings) => {
+        if (!settings.edit_metadata) {
+            return;
+        }
+
         let inputId = `redact-value-${keyname}`;
         let inputField = $(`<input type="text" id="${inputId}" class="wsi-deid-replace-value-input">`);
 

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -377,7 +377,7 @@ wrap(ItemView, 'render', function (render) {
             this.events['change .g-hui-redact'] = flagRedaction;
             this.events['click a.g-hui-redact'] = flagRedaction;
             this.events['click .g-hui-redact-square-span'] = flagRedaction;
-            this.events['focusout .wsi-deid-replace-value'] = flagRedaction;
+            this.events['change .wsi-deid-replace-value'] = flagRedaction;
             this.events['click .g-hui-redact-label'] = (event) => {
                 event.stopPropagation();
                 return false;

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -216,6 +216,13 @@ wrap(ItemView, 'render', function (render) {
         parentElem.append(elem);
     };
 
+    const addNewValueEntryField = (parentElem, keyname, redactRecord, settings) => {
+        let inputId = `redact-value-${keyname}`;
+        let input = $(`<label for="${inputId}">New value:</label><input type="text" id="${inputId}" class="wsi-deid-replace-value-input">`);
+        input = $('<span class="wsi-deid-replace-value"></span>').append(input);
+        parentElem.append(input);
+    };
+
     const hideField = (keyname, hideFieldPatterns) => {
         for (const metadataPattern in hideFieldPatterns) {
             if (keyname.match(new RegExp(metadataPattern))) {
@@ -292,6 +299,7 @@ wrap(ItemView, 'render', function (render) {
                     redactButtonAllowed = false;
                 }
                 if (showRedactButton(keyname, disableRedactionPatterns) && redactButtonAllowed) {
+                    addNewValueEntryField(elem, keyname, redactList.metadata[keyname], settings);
                     addRedactButton(elem, keyname, redactList.metadata[keyname], 'metadata', settings);
                 }
                 elem.toggleClass('redacted', isRedacted);


### PR DESCRIPTION
Closes #201 
This change adds a new setting, `edit_metadata`. It should be set to either `True` or `False`. This setting controls whether or not metadata values can be edited by end users as part of the redaction process.

The workflow for editing metadata values is as follows:

1. A user opts to redact a piece of metadata by clicking the `REDACT` button or choosing a reason from the drop-down menu
2. If editing metadata is turned on, an input field appears with the label `New Value`. Users can enter a new value for this metadata field here.
3. Upon redaction (by clicking the `Redact` button), the new value will be written into that metadata field.

This workflow is off by default. In order to turn it on, `girder.local.conf` must contain `edit_metadata = True`.

Documentation has been updated to include an explanation of the setting and workflow.

Additionally, system-performed metadata redaction now has its own redaction reason: `System Redacted`. This allows for more clarity in the redaction list. Users cannot select this as a redaction reason. It is only used during the import process, when generating the initial list of reacted fields.