### PR TITLE
Add ability to run OCR on imported images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,7 @@ jobs:
           command: npm install -g phantomjs-prebuilt --unsafe-perm
       - run:
           name: Run server tests
-          command: | 
-            PYTHONUNBUFFERED=1
-            tox
+          command: tox
       - run:
           name: Run web tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,11 @@ jobs:
           name: Preinstall phantomjs to work around an npm permission issue
           command: npm install -g phantomjs-prebuilt --unsafe-perm
       - run:
+          name: Install libraries for easyocr
+          command: apt-get update && apt-get install ffmpeg libsm6 libxext6 -y
+      - run:
           name: Run server tests
+          no_output_timeout: 15m
           command: tox
       - run:
           name: Run web tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,9 @@ jobs:
           command: npm install -g phantomjs-prebuilt --unsafe-perm
       - run:
           name: Run server tests
-          command: tox
+          command: | 
+            PYTHONUNBUFFERED=1
+            tox
       - run:
           name: Run web tests
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && \
     # libsasl2-dev \
     curl \
     ca-certificates \
-    vim && \
+    vim \
+    tesseract-ocr && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN curl -LJ https://github.com/krallin/tini/releases/download/v0.19.0/tini -o /usr/bin/tini && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,6 @@ RUN apt-get update && \
     libxext6 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# RUN apt-get update && \
-    # apt-get install ffmpeg libsm6 libxext6 -y
-
 RUN curl -LJ https://github.com/krallin/tini/releases/download/v0.19.0/tini -o /usr/bin/tini && \
     chmod +x /usr/bin/tini
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,13 @@ RUN apt-get update && \
     curl \
     ca-certificates \
     vim \
-    tesseract-ocr && \
+    ffmpeg \
+    libsm6 \
+    libxext6 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# RUN apt-get update && \
+    # apt-get install ffmpeg libsm6 libxext6 -y
 
 RUN curl -LJ https://github.com/krallin/tini/releases/download/v0.19.0/tini -o /usr/bin/tini && \
     chmod +x /usr/bin/tini

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'pyvips',
         'tifftools',
         'xlrd',
+        'pytesseract',
     ],
     license='Apache Software License 2.0',
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'tifftools',
         'xlrd',
         'pytesseract',
+        'easyocr',
     ],
     license='Apache Software License 2.0',
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     description='Digital Slide Archive Whole-Slide Image DeIdentification plugin',
     install_requires=[
         'celery<5',
+        'easyocr==1.4',
         'girder-homepage',
         'histomicsui',
         'jsonschema',
@@ -53,8 +54,6 @@ setup(
         'pyvips',
         'tifftools',
         'xlrd',
-        'pytesseract',
-        'easyocr',
     ],
     license='Apache Software License 2.0',
     long_description=readme,

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     description='Digital Slide Archive Whole-Slide Image DeIdentification plugin',
     install_requires=[
         'celery<5',
-        'easyocr==1.4',
+        'easyocr!=1.4.1',
         'girder-homepage',
         'histomicsui',
         'jsonschema',

--- a/wsi_deid/__init__.py
+++ b/wsi_deid/__init__.py
@@ -40,10 +40,8 @@ def start_ocr_item_job(job):
         )
         return
     item = job_args[0]
-    global reader
-    if reader is None:
-        reader = easyocr.Reader(['en'], gpu=False, verbose=False)
-    label_text = get_image_text(item, reader)
+    ocr_reader = get_reader()
+    label_text = get_image_text(item, ocr_reader)
     Job().updateJob(
         job, log=f'Found text "{label_text}" in file {item["name"]}\n', status=JobStatus.SUCCESS)
 
@@ -55,7 +53,7 @@ def start_ocr_batch_job(job):
 
     :param job: A girder job
     """
-    Job().updateJob(job, log='Starting batch job to OCR newly imported items\n\n', status=JobStatus.RUNNING)
+    Job().updateJob(job, log='Starting batch job to find label text on items...\n\n', status=JobStatus.RUNNING)
     job_args = job.get('args', None)
     if job_args is None:
         Job().updateJob(job, log=f'Expected a list of girder items as an argument.\n', status=JobStatus.ERROR)

--- a/wsi_deid/__init__.py
+++ b/wsi_deid/__init__.py
@@ -104,6 +104,7 @@ def validateSettingsFolder(doc):
     PluginSettings.WSI_DEID_REMOTE_HOST,
     PluginSettings.WSI_DEID_REMOTE_USER,
     PluginSettings.WSI_DEID_REMOTE_PASSWORD,
+    PluginSettings.WSI_DEID_OCR_ON_IMPORT,
 })
 def validateSettingsImportExport(doc):
     if not doc.get('value', None):

--- a/wsi_deid/__init__.py
+++ b/wsi_deid/__init__.py
@@ -19,16 +19,18 @@ from .process import get_image_text
 # set up asynchronously running ocr
 reader = None
 
+
 def handle_ocr_item(event):
+    print("\n\n\nHANDLING EVENT")
     global reader
     if reader is None:
         reader = easyocr.Reader(['en'], gpu=False)
     item = event.info['item']
     ocr_results = get_image_text(item, reader)
-    # TODO fix File already exists
-    print(f'\n\n\nRESULTS: {ocr_results}')
+
 
 events.bind('wsi_deid.ocr_item', 'ocr_handler', handle_ocr_item)
+
 
 try:
     __version__ = get_distribution(__name__).version

--- a/wsi_deid/__init__.py
+++ b/wsi_deid/__init__.py
@@ -35,9 +35,10 @@ def start_ocr_item_job(job):
     item = job_args[0]
     global reader
     if reader is None:
-        reader = easyocr.Reader(['en'], gpu=False)
+        reader = easyocr.Reader(['en'], gpu=False, verbose=False)
     label_text = get_image_text(item, reader)
-    Job().updateJob(job, log=f'Found text "{label_text}" in file {item["name"]}\n', status=JobStatus.SUCCESS)
+    Job().updateJob(
+        job, log=f'Found text "{label_text}" in file {item["name"]}\n', status=JobStatus.SUCCESS)
 
 
 def handle_ocr_item(event):

--- a/wsi_deid/__init__.py
+++ b/wsi_deid/__init__.py
@@ -96,6 +96,7 @@ def start_ocr_batch_job(job):
             status=JobStatus.ERROR,
         )
 
+
 try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:

--- a/wsi_deid/__init__.py
+++ b/wsi_deid/__init__.py
@@ -21,7 +21,6 @@ reader = None
 
 
 def handle_ocr_item(event):
-    print("\n\n\nHANDLING EVENT")
     global reader
     if reader is None:
         reader = easyocr.Reader(['en'], gpu=False)
@@ -29,7 +28,7 @@ def handle_ocr_item(event):
     ocr_results = get_image_text(item, reader)
 
 
-events.bind('wsi_deid.ocr_item', 'ocr_handler', handle_ocr_item)
+events.bind('wsi_deid.ocr_item', 'handle_ocr_item', handle_ocr_item)
 
 
 try:

--- a/wsi_deid/constants.py
+++ b/wsi_deid/constants.py
@@ -19,6 +19,7 @@ class PluginSettings(object):
     WSI_DEID_REMOTE_PASSWORD = 'wsi_deid.remote_password'
     WSI_DEID_REMOTE_PORT = 'wsi_deid.remote_port'
     WSI_DEID_SFTP_MODE = 'wsi_deid.sftp_mode'
+    WSI_DEID_OCR_ON_IMPORT = 'wsi_deid.ocr_on_import'
 
 
 class SftpMode(Enum):

--- a/wsi_deid/import_export.py
+++ b/wsi_deid/import_export.py
@@ -227,7 +227,6 @@ def ingestOneItem(importFolder, imagePath, record, ctx, user, newItems):
         ctx.update(message='Failed to import %s' % name)
         return 'failed'
     item = Item().setMetadata(item, {'redactList': redactList})
-    # events.daemon.trigger('wsi_deid.ocr_item', item)
     newItems.append(item['_id'])
     ctx.update(message='Imported %s' % name)
     return status

--- a/wsi_deid/import_export.py
+++ b/wsi_deid/import_export.py
@@ -300,18 +300,19 @@ def ingestData(ctx, user=None):  # noqa
         status = 'unlisted'
         report.append({'record': None, 'status': status, 'path': image})
     # kick off a batch job to run OCR on new items
-    start_ocr_during_import = Setting().get(PluginSettings.WSI_DEID_OCR_ON_IMPORT)
-    if start_ocr_during_import:
-        batch_job = Job().createLocalJob(
+    startOcrDuringImport = Setting().get(PluginSettings.WSI_DEID_OCR_ON_IMPORT)
+    if startOcrDuringImport and len(newItems) > 1:
+        jobStart = datetime.datetime.now().strftime("%Y%m%d %H%M%S")
+        batchJob = Job().createLocalJob(
             module='wsi_deid',
             function='start_ocr_batch_job',
-            title=f'Batch OCR triggered by import: {user["login"]}, {datetime.datetime.now().strftime("%Y%m%d %H%M%S")}',
+            title=f'Batch OCR triggered by import: {user["login"]}, {jobStart}',
             type='wsi_deid.batch_ocr',
             user=user,
             asynchronous=True,
             args=(newItems,),
         )
-        Job().scheduleJob(job=batch_job)
+        Job().scheduleJob(job=batchJob)
     file = importReport(ctx, report, excelReport, user, importPath)
     return reportSummary(report, excelReport, file=file)
 

--- a/wsi_deid/import_export.py
+++ b/wsi_deid/import_export.py
@@ -225,8 +225,7 @@ def ingestOneItem(importFolder, imagePath, record, ctx, user):
         ctx.update(message='Failed to import %s' % name)
         return 'failed'
     item = Item().setMetadata(item, {'redactList': redactList})
-    # TESTING
-    events.daemon.trigger('wsi_deid.ocr_item', {'item': item})
+    events.daemon.trigger('wsi_deid.ocr_item', item)
     ctx.update(message='Imported %s' % name)
     return status
 

--- a/wsi_deid/import_export.py
+++ b/wsi_deid/import_export.py
@@ -10,7 +10,7 @@ import magic
 import openpyxl
 import pandas as pd
 import paramiko
-from girder import logger
+from girder import logger, events
 from girder.models.assetstore import Assetstore
 from girder.models.file import File
 from girder.models.folder import Folder
@@ -225,6 +225,8 @@ def ingestOneItem(importFolder, imagePath, record, ctx, user):
         ctx.update(message='Failed to import %s' % name)
         return 'failed'
     item = Item().setMetadata(item, {'redactList': redactList})
+    # TESTING
+    events.daemon.trigger('wsi_deid.ocr_item', {'item': item})
     ctx.update(message='Imported %s' % name)
     return status
 

--- a/wsi_deid/import_export.py
+++ b/wsi_deid/import_export.py
@@ -313,7 +313,10 @@ def ingestData(ctx, user=None):  # noqa
         )
         Job().scheduleJob(job=batchJob)
     file = importReport(ctx, report, excelReport, user, importPath)
-    return reportSummary(report, excelReport, file=file)
+    summary = reportSummary(report, excelReport, file=file)
+    if startOcrDuringImport:
+        summary['ocr_job'] = batchJob['_id']
+    return summary
 
 
 def importReport(ctx, report, excelReport, user, importPath):

--- a/wsi_deid/import_export.py
+++ b/wsi_deid/import_export.py
@@ -10,8 +10,7 @@ import magic
 import openpyxl
 import pandas as pd
 import paramiko
-from girder import logger, events
-from girder_jobs.models.job import Job
+from girder import logger
 from girder.models.assetstore import Assetstore
 from girder.models.file import File
 from girder.models.folder import Folder
@@ -302,7 +301,7 @@ def ingestData(ctx, user=None):  # noqa
     # kick off a batch job to run OCR on new items
     startOcrDuringImport = Setting().get(PluginSettings.WSI_DEID_OCR_ON_IMPORT)
     if startOcrDuringImport and len(newItems) > 1:
-        jobStart = datetime.datetime.now().strftime("%Y%m%d %H%M%S")
+        jobStart = datetime.datetime.now().strftime('%Y%m%d %H%M%S')
         batchJob = Job().createLocalJob(
             module='wsi_deid',
             function='start_ocr_batch_job',

--- a/wsi_deid/import_export.py
+++ b/wsi_deid/import_export.py
@@ -300,16 +300,18 @@ def ingestData(ctx, user=None):  # noqa
         status = 'unlisted'
         report.append({'record': None, 'status': status, 'path': image})
     # kick off a batch job to run OCR on new items
-    batch_job = Job().createLocalJob(
-        module='wsi_deid',
-        function='start_ocr_batch_job',
-        title=f'Batch OCR triggered by import: {user["login"]}, {datetime.datetime.now().strftime("%Y%m%d %H%M%S")}',
-        type='wsi_deid.batch_ocr',
-        user=user,
-        asynchronous=True,
-        args=(newItems,),
-    )
-    Job().scheduleJob(job=batch_job)
+    start_ocr_during_import = Setting().get(PluginSettings.WSI_DEID_OCR_ON_IMPORT)
+    if start_ocr_during_import:
+        batch_job = Job().createLocalJob(
+            module='wsi_deid',
+            function='start_ocr_batch_job',
+            title=f'Batch OCR triggered by import: {user["login"]}, {datetime.datetime.now().strftime("%Y%m%d %H%M%S")}',
+            type='wsi_deid.batch_ocr',
+            user=user,
+            asynchronous=True,
+            args=(newItems,),
+        )
+        Job().scheduleJob(job=batch_job)
     file = importReport(ctx, report, excelReport, user, importPath)
     return reportSummary(report, excelReport, file=file)
 

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -8,7 +8,6 @@ import subprocess
 import threading
 import xml.etree.ElementTree
 import easyocr
-import traceback
 import PIL.Image
 import PIL.ImageDraw
 import PIL.ImageFont
@@ -1276,6 +1275,15 @@ def get_text_from_associated_image(tile_source, label, reader):
                 words.append(word)
     return words
 
+
+def add_label_text_to_tiff_tags(item, text):
+    tile_source = ImageItem().tileSource(item)
+    source_path = tile_source._getLargeImagePath()
+    tiffinfo = tifftools.read_tiff(source_path)
+    logger.info(f'TILE SOURCE: {tile_source}')
+    logger.info(f'\n{list(tile_source.__dict__)}\n')
+
+
 def get_image_text(item, reader=None):
     """
     Use OCR to identify and return text on any associated image.
@@ -1295,5 +1303,6 @@ def get_image_text(item, reader=None):
         key = 'macro'
     results = get_text_from_associated_image(tile_source, key, reader)
     # TODO: Evaluate adding this to the .tiff file metadata
+    add_label_text_to_tiff_tags(item, results)
     item = ImageItem().setMetadata(item, {'label_ocr': results})
     return results

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -7,6 +7,7 @@ import re
 import subprocess
 import threading
 import xml.etree.ElementTree
+
 import easyocr
 import PIL.Image
 import PIL.ImageDraw
@@ -1255,7 +1256,7 @@ def redact_topleft_square(image):
 
 def image_to_byte_array(image):
     image_byte_array = io.BytesIO()
-    image.save(image_byte_array, "tiff")
+    image.save(image_byte_array, 'tiff')
     image_byte_array = image_byte_array.getvalue()
     return image_byte_array
 
@@ -1276,14 +1277,6 @@ def get_text_from_associated_image(tile_source, label, reader):
     return words
 
 
-def add_label_text_to_tiff_tags(item, text):
-    tile_source = ImageItem().tileSource(item)
-    source_path = tile_source._getLargeImagePath()
-    tiffinfo = tifftools.read_tiff(source_path)
-    logger.info(f'TILE SOURCE: {tile_source}')
-    logger.info(f'\n{list(tile_source.__dict__)}\n')
-
-
 def get_image_text(item, reader=None):
     """
     Use OCR to identify and return text on any associated image.
@@ -1302,7 +1295,6 @@ def get_image_text(item, reader=None):
     elif image_format == 'hamamatsu':
         key = 'macro'
     results = get_text_from_associated_image(tile_source, key, reader)
-    # TODO: Evaluate adding this to the .tiff file metadata
-    add_label_text_to_tiff_tags(item, results)
+    # TODO: Consider adding this to the .tiff file metadata
     item = ImageItem().setMetadata(item, {'label_ocr': results})
     return results

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -1255,7 +1255,7 @@ def redact_topleft_square(image):
     return newImage
 
 def get_text_from_image(image):
-    ocr_results = []
+    words = {}
     for crop, rotate, contrast in itertools.product(
         (0, 1, 2),
         (None, PIL.Image.ROTATE_90, PIL.Image.ROTATE_180, PIL.Image.ROTATE_270),
@@ -1268,8 +1268,11 @@ def get_text_from_image(image):
             subimage = getattr(PIL.ImageOps, contrast)(subimage)
         text = pytesseract.image_to_string(subimage).strip()
         if len(text) > 0:
-            ocr_results.append(text)
-    return ocr_results
+            # split text into words
+            text_parts = [word for word in text.split() if re.search(r'\w', word)]
+            for word in text_parts:
+                words[word] = 1
+    return list(words)
 
 
 def get_image_text(item):

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -1283,8 +1283,7 @@ def get_image_text(item, reader=None):
 
     :param item: a girder item.
     :param reader: an EasyOCR reader object. If a reader is not provided, one will be created.
-    :returns: a dictionary of found text in the format {key: []}. `key` will be the associated
-    image key, and `[]` will be a list of possible strings of text found on the associated image.
+    :returns: a list of found text .
     """
     if reader is None:
         reader = easyocr.Reader(['en'], gpu=False)

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -1274,8 +1274,7 @@ def get_text_from_associated_image(tile_source, label, reader):
         for word in text:
             if re.search(r'\w', word):
                 words.append(word)
-    return ", ".join(set(words))
-
+    return words
 
 def get_image_text(item, reader=None):
     """

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -1257,7 +1257,7 @@ def get_image_text(item):
     Use OCR (pytesseract) to identify and return text on any associated image.
 
     :param item: a girder item.
-    :returns: a dictionary of found text in the format {key: []}. `key` will be the associated image key, and `[]`
-    will be a list of possible strings of text found on the associated image.
+    :returns: a dictionary of found text in the format {key: []}. `key` will be the associated
+    image key, and `[]` will be a list of possible strings of text found on the associated image.
     """
     pass

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -1250,3 +1250,14 @@ def redact_topleft_square(image):
     imageDraw = PIL.ImageDraw.Draw(newImage)
     imageDraw.rectangle((0, 0, min(w, h), min(w, h)), fill=background, outline=None, width=0)
     return newImage
+
+
+def get_image_text(item):
+    """
+    Use OCR (pytesseract) to identify and return text on any associated image.
+
+    :param item: a girder item.
+    :returns: a dictionary of found text in the format {key: []}. `key` will be the associated image key, and `[]`
+    will be a list of possible strings of text found on the associated image.
+    """
+    pass

--- a/wsi_deid/rest.py
+++ b/wsi_deid/rest.py
@@ -190,15 +190,11 @@ def process_item(item, user=None):
     return item
 
 
-def after_ocr(event):
-    print('\n\n\nEVENT CALLBACK\n\n')
-    print(process.get_ifd_zero(event.info['item'])['tags']['label_ocr'])
-
 def ocr_item(item, user=None):
     client_message = 'Success'
     try:
         event_info = {'item': item}
-        events.daemon.trigger('wsi_deid.ocr_item', info=event_info, callback=after_ocr)
+        events.daemon.trigger('wsi_deid.ocr_item', info=event_info)
     except Exception as e:
         client_message = str(e)
     return client_message

--- a/wsi_deid/rest.py
+++ b/wsi_deid/rest.py
@@ -191,7 +191,7 @@ def process_item(item, user=None):
 
 def ocr_item(item, user=None):
     return {
-        'ocr_reesults': 'Not implemented yet',
+        'ocr_results': process.get_image_text(item),
         'item': str(item['_id']),
         'user': str(user['_id']),
     }

--- a/wsi_deid/rest.py
+++ b/wsi_deid/rest.py
@@ -243,6 +243,7 @@ class WSIDeIDResource(Resource):
         self.route('PUT', ('action', 'exportall'), self.exportAll)
         self.route('GET', ('settings',), self.getSettings)
         self.route('GET', ('resource', ':id', 'subtreeCount'), self.getSubtreeCount)
+        self.route('GET', ('item', ':id', 'ocr'), self.getOCRResults)
 
     @autoDescribeRoute(
         Description('Check if a folder is a project folder.')
@@ -369,3 +370,16 @@ class WSIDeIDResource(Resource):
         folderCount = model.subtreeCount(doc, False, user=user, level=AccessType.READ)
         totalCount = model.subtreeCount(doc, True, user=user, level=AccessType.READ)
         return {'folders': folderCount, 'items': totalCount - folderCount, 'total': totalCount}
+
+    @access.user
+    @autoDescribeRoute(
+        Description('Run OCR on an item and return the results.')
+        .modelParam('id', model=Item, level=AccessType.READ)
+        .errorResponse()
+        .errorResponse('Write access was denied on the item.', 403)
+    )
+    def getOCRResults(self, item):
+        return {
+            'status': 'not implemented yet',
+            'item': str(item),
+        }

--- a/wsi_deid/rest.py
+++ b/wsi_deid/rest.py
@@ -189,6 +189,14 @@ def process_item(item, user=None):
     return item
 
 
+def ocr_item(item, user=None):
+    return {
+        'ocr_reesults': 'Not implemented yet',
+        'item': str(item['_id']),
+        'user': str(user['_id']),
+    }
+
+
 def get_first_item(folder, user):
     """
     Get the first item in a folder or any subfolder of that folder.  The items
@@ -243,7 +251,6 @@ class WSIDeIDResource(Resource):
         self.route('PUT', ('action', 'exportall'), self.exportAll)
         self.route('GET', ('settings',), self.getSettings)
         self.route('GET', ('resource', ':id', 'subtreeCount'), self.getSubtreeCount)
-        self.route('GET', ('item', ':id', 'ocr'), self.getOCRResults)
 
     @autoDescribeRoute(
         Description('Check if a folder is a project folder.')
@@ -269,7 +276,7 @@ class WSIDeIDResource(Resource):
         .modelParam('id', model=Item, level=AccessType.READ)
         .param('action', 'Action to perform on the item.  One of process, '
                'reject, quarantine, unquarantine, finish.', paramType='path',
-               enum=['process', 'reject', 'quarantine', 'unquarantine', 'finish'])
+               enum=['process', 'reject', 'quarantine', 'unquarantine', 'finish', 'ocr'])
         .errorResponse()
         .errorResponse('Write access was denied on the item.', 403)
     )
@@ -283,6 +290,7 @@ class WSIDeIDResource(Resource):
             'reject': (move_item, (item, user, PluginSettings.HUI_REJECTED_FOLDER)),
             'finish': (move_item, (item, user, PluginSettings.HUI_FINISHED_FOLDER)),
             'process': (process_item, (item, user)),
+            'ocr': (ocr_item, (item, user)),
         }
         actionfunc, actionargs = actionmap[action]
         return actionfunc(*actionargs)
@@ -370,16 +378,3 @@ class WSIDeIDResource(Resource):
         folderCount = model.subtreeCount(doc, False, user=user, level=AccessType.READ)
         totalCount = model.subtreeCount(doc, True, user=user, level=AccessType.READ)
         return {'folders': folderCount, 'items': totalCount - folderCount, 'total': totalCount}
-
-    @access.user
-    @autoDescribeRoute(
-        Description('Run OCR on an item and return the results.')
-        .modelParam('id', model=Item, level=AccessType.READ)
-        .errorResponse()
-        .errorResponse('Write access was denied on the item.', 403)
-    )
-    def getOCRResults(self, item):
-        return {
-            'status': 'not implemented yet',
-            'item': str(item),
-        }

--- a/wsi_deid/rest.py
+++ b/wsi_deid/rest.py
@@ -363,11 +363,12 @@ class WSIDeIDResource(Resource):
         ingestFolder = Folder().load(Setting().get(
             PluginSettings.HUI_INGEST_FOLDER), user=user, level=AccessType.WRITE
         )
-        resp = { 'action': 'ocrall' }
+        resp = {'action': 'ocrall'}
         for _, file in Folder().fileList(ingestFolder, user, data=False):
             itemId = file['itemId']
             item = Item().load(itemId, force=True)
-            if item.get('meta', {}).get('label_ocr', None) is None:
+            if (item.get('meta', {}).get('label_ocr', None) is None and
+                    item.get('meta', {}).get('macro_ocr', None) is None):
                 itemIds.append(file['itemId'])
         if len(itemIds) > 0:
             jobStart = datetime.datetime.now().strftime('%Y%m%d %H%M%S')
@@ -383,7 +384,6 @@ class WSIDeIDResource(Resource):
             Job().scheduleJob(job=batchJob)
             resp['ocrJobId'] = batchJob['_id']
         return resp
-
 
     @autoDescribeRoute(
         Description('Get the ID of the next unprocessed item.')

--- a/wsi_deid/rest.py
+++ b/wsi_deid/rest.py
@@ -197,7 +197,7 @@ def ocr_item(item, user):
         module='wsi_deid',
         function='start_ocr_item_job',
         title=job_title,
-        type='wsi_deid_ocr_job',
+        type='wsi_deid.ocr_job',
         user=user,
         asynchronous=True,
         args=(item,)

--- a/wsi_deid/rest.py
+++ b/wsi_deid/rest.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import tempfile
+import easyocr
 
 import histomicsui.handlers
 from girder import logger
@@ -31,6 +32,7 @@ ProjectFolders = {
     'finished': PluginSettings.HUI_FINISHED_FOLDER,
 }
 
+easyocr_reader = None
 
 def create_folder_hierarchy(item, user, folder):
     """
@@ -190,7 +192,10 @@ def process_item(item, user=None):
 
 
 def ocr_item(item, user=None):
-    ocr_results, time = process.get_image_text(item)
+    global easyocr_reader
+    if easyocr_reader is None:
+        easyocr_reader = easyocr.Reader(['en'], gpu=False)
+    ocr_results, time = process.get_image_text(item, easyocr_reader)
     return {
         'ocr_results': ocr_results,
         'time_elapsed': time,

--- a/wsi_deid/rest.py
+++ b/wsi_deid/rest.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import tempfile
-import easyocr
 
 import histomicsui.handlers
 from girder import logger, events

--- a/wsi_deid/rest.py
+++ b/wsi_deid/rest.py
@@ -190,10 +190,10 @@ def process_item(item, user=None):
 
 
 def ocr_item(item, user=None):
+    ocr_results, time = process.get_image_text(item)
     return {
-        'ocr_results': process.get_image_text(item),
-        'item': str(item['_id']),
-        'user': str(user['_id']),
+        'ocr_results': ocr_results,
+        'time_elapsed': time,
     }
 
 

--- a/wsi_deid/rest.py
+++ b/wsi_deid/rest.py
@@ -198,14 +198,14 @@ def ocr_item(item, user):
         function='start_ocr_item_job',
         title=job_title,
         type='wsi_deid_ocr_job',
-        userId = user.get('_id', None),
+        user=user,
         asynchronous=True,
         args=(item,)
     )
     Job().scheduleJob(job=ocr_job)
     return {
-        'job_id': ocr_job._id,
-        'job_title': ocr_job.title,
+        'job_id': ocr_job.get('_id', None),
+        'job_title': ocr_job.get('title', None),
     }
 
 

--- a/wsi_deid/rest.py
+++ b/wsi_deid/rest.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 
 import histomicsui.handlers
-from girder import logger, events
+from girder import logger
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
 from girder.api.rest import Resource
@@ -261,6 +261,7 @@ class WSIDeIDResource(Resource):
         self.route('PUT', ('action', 'ingest'), self.ingest)
         self.route('PUT', ('action', 'export'), self.export)
         self.route('PUT', ('action', 'exportall'), self.exportAll)
+        self.route('PUT', ('action', 'ocrall'), self.ocrReadyToProcess)
         self.route('GET', ('settings',), self.getSettings)
         self.route('GET', ('resource', ':id', 'subtreeCount'), self.getSubtreeCount)
 
@@ -352,6 +353,17 @@ class WSIDeIDResource(Resource):
             result = import_export.exportItems(ctx, user, True)
         result['action'] = 'exportall'
         return result
+
+    @autoDescribeRoute(
+        Description('Run OCR to find label text on all items in the import folder')
+        .errorResponse()
+    )
+    @access.user
+    def ocrReadyToProcess(self):
+        return {
+            'message': 'OCR all not implemented yet',
+            'action': 'ocrall'
+        }
 
     @autoDescribeRoute(
         Description('Get the ID of the next unprocessed item.')

--- a/wsi_deid/web_client/templates/ConfigView.pug
+++ b/wsi_deid/web_client/templates/ConfigView.pug
@@ -142,6 +142,11 @@ form#g-wsi_deid-form(role="form")
       option(value='local', selected=(settings['wsi_deid.sftp_mode'] === 'local')) Local export only
       option(value='remote', selected=(settings['wsi_deid.sftp_mode'] === 'remote')) Remote (SFTP) transfer only
       option(value='both', selected=(settings['wsi_deid.sftp_mode'] === 'both')) Local export and remote transfer
+  .form-group
+    label(for="g-wsi-deid-ocr-on-import") Find Label Text on Import
+    p.g-hui-description
+      | Kick off a local job to find label text on new images during an import
+    input#g-wsi-deid-ocr-on-import.input-sm(type="checkbox", checked=(settings['wsi_deid.ocr_on_import'] ? "checked" : undefined))
   p#g-hui-error-message.g-validation-failed-message
 .g-hui-buttons
   button#g-hui-save.btn.btn-sm.btn-primary Save

--- a/wsi_deid/web_client/templates/ItemView.pug
+++ b/wsi_deid/web_client/templates/ItemView.pug
@@ -13,9 +13,7 @@
     quarantine: {name: 'Quarantine', title: 'Move this image to the quarantined folder for redaction', color: 'warning'},
     unquarantine: {name: 'Undo Quarantine', title: 'Move this image back to its previous location before it was quarantined', color: 'default'},
     finish: {name: 'Approve', title: 'Move this image to the approved folder', color: 'primary'},
-
-    // WIP
-    ocr: {name: 'OCR', title: 'Perform OCR on this image', color: 'default'},
+    ocr: {name: 'Find Label Text', title: 'Perform OCR on this image', color: 'default'},
   };
   var buttonList = folderButtonList[project_folder] || ['quarantine']
 

--- a/wsi_deid/web_client/templates/ItemView.pug
+++ b/wsi_deid/web_client/templates/ItemView.pug
@@ -1,6 +1,6 @@
 -
   var folderButtonList = {
-    ingest: ['process', 'reject', 'quarantine'],
+    ingest: ['process', 'reject', 'quarantine', 'ocr'],
     quarantine: ['process', 'reject', 'unquarantine'],
     processed: ['quarantine', 'finish'],
     rejected: ['quarantine'],
@@ -13,6 +13,9 @@
     quarantine: {name: 'Quarantine', title: 'Move this image to the quarantined folder for redaction', color: 'warning'},
     unquarantine: {name: 'Undo Quarantine', title: 'Move this image back to its previous location before it was quarantined', color: 'default'},
     finish: {name: 'Approve', title: 'Move this image to the approved folder', color: 'primary'},
+
+    // WIP
+    ocr: {name: 'OCR', title: 'Perform OCR on this image', color: 'default'},
   };
   var buttonList = folderButtonList[project_folder] || ['quarantine']
 

--- a/wsi_deid/web_client/utils.js
+++ b/wsi_deid/web_client/utils.js
@@ -30,41 +30,6 @@ function goToNextUnprocessedItem(callback) {
     return false;
 }
 
-function pollForOcrResults(itemId, callback, maxAttempts) {
-    let gotOcrData = false;
-    let attempts = 0;
-
-    const executePoll = () => {
-        attempts++;
-        restRequest({
-            url: 'item/' + itemId,
-            error: null
-        }).done((resp) => {
-            if (gotOcrData) {
-                callback(resp['meta']['label_ocr']);
-            } else if (attempts >= maxAttempts) {
-                callback('Too many attempts');
-            } else {
-                setTimeout(executePoll, 1000);
-            }
-        });
-    };
-    restRequest({
-        url: 'item/' + itemId,
-        error: null
-    }).done((resp) => {
-        gotOcrData = resp['meta']['label_ocr'];
-        if (gotOcrData) {
-            callback(resp['meta']['label_ocr']);
-        } else if (attempts >= maxAttempts) {
-            callback('Too many attempts');
-        } else {
-            setTimeout(executePoll, 1000);
-        }
-    });
-    return false;
-}
-
 export {
-    goToNextUnprocessedItem, pollForOcrResults
+    goToNextUnprocessedItem
 };

--- a/wsi_deid/web_client/views/ConfigView.js
+++ b/wsi_deid/web_client/views/ConfigView.js
@@ -58,7 +58,8 @@ var ConfigView = View.extend({
             'wsi_deid.remote_port': { name: 'Remote SFTP Port', id: 'g-wsi-deid-remote-port' },
             'wsi_deid.remote_user': { name: 'Remote SFTP User', id: 'g-wsi-deid-remote-user' },
             'wsi_deid.remote_password': { name: 'Remote SFTP Password', id: 'g-wsi-deid-remote-password' },
-            'wsi_deid.sftp_mode': { name: 'SFTP Mode', id: 'g-wsi-deid-sftp-mode' }
+            'wsi_deid.sftp_mode': { name: 'SFTP Mode', id: 'g-wsi-deid-sftp-mode' },
+            'wsi_deid.ocr_on_import': { name: 'Find Label Text on Import', id: 'g-wsi-deid-ocr-on-import' }
         };
         this._browserWidgetView = {};
         $.when(

--- a/wsi_deid/web_client/views/HierarchyWidget.js
+++ b/wsi_deid/web_client/views/HierarchyWidget.js
@@ -81,9 +81,13 @@ function performAction(action) {
             }
         }
         if (resp.action === 'ocrall') {
-            events.once('g:alert', () => {
-                $('#g-alerts-container:last div.alert:last').append($('<span> </span>')).append($('<a/>').text('Track its progress here.').attr('href', `/#job/${resp.ocrJobId}`));
-            }, this);
+            if (resp.ocrJobId) {
+                events.once('g:alert', () => {
+                    $('#g-alerts-container:last div.alert:last').append($('<span> </span>')).append($('<a/>').text('Track its progress here.').attr('href', `/#job/${resp.ocrJobId}`));
+                }, this);
+            } else {
+                text = 'No new items without existing label text metadata.';
+            }
         }
         if (resp.fileId) {
             events.once('g:alert', () => {

--- a/wsi_deid/web_client/views/HierarchyWidget.js
+++ b/wsi_deid/web_client/views/HierarchyWidget.js
@@ -13,7 +13,8 @@ function performAction(action) {
     const actions = {
         ingest: { done: 'Import completed.', fail: 'Failed to import.' },
         export: { done: 'Recent export task completed.', fail: 'Failed to export recent items.  Check export file location for disk drive space or other system issues.' },
-        exportall: { done: 'Export all task completed.', fail: 'Failed to export all items.  Check export file location for disk drive space or other system issues.' }
+        exportall: { done: 'Export all task completed.', fail: 'Failed to export all items.  Check export file location for disk drive space or other system issues.' },
+        ocrall: { fail: 'Failed to start background task to find label text for images.'}
     };
 
     restRequest({
@@ -79,6 +80,11 @@ function performAction(action) {
                 }
             }
         }
+        if (resp.action === 'ocrall') {
+            // TODO alert user with job id
+            console.log(resp);
+            return;
+        }
         if (resp.fileId) {
             events.once('g:alert', () => {
                 $('#g-alerts-container:last div.alert:last').append($('<span> </span>')).append($('<a/>').text('See the Excel report for more details.').attr('href', `/api/v1/file/${resp.fileId}/download`));
@@ -121,8 +127,12 @@ function performAction(action) {
 
 function addIngestControls() {
     var btns = this.$el.find('.g-hierarchy-actions-header .g-folder-header-buttons');
-    btns.prepend('<button class="wsi_deid-import-button btn btn-info">Import</button>');
+    btns.prepend(
+        '<button class="wsi_deid-import-button btn btn-info">Import</button>' +
+        '<button class="wsi_deid-ocr-button btn btn-info">Find label text</button>'
+    );
     this.events['click .wsi_deid-import-button'] = () => { performAction.call(this, 'ingest'); };
+    this.events['click .wsi_deid-ocr-button'] = () => { performAction.call(this, 'ocrall'); };
     this.delegateEvents();
 }
 

--- a/wsi_deid/web_client/views/HierarchyWidget.js
+++ b/wsi_deid/web_client/views/HierarchyWidget.js
@@ -104,6 +104,14 @@ function performAction(action) {
                 $('#g-alerts-container:last div.alert:last').append(sftpAlertInfo);
             }, this);
         }
+        if (resp.action === 'ingest' && resp['ocr_job']) {
+            // If import launches an ocr batch job, add that info at the very end of the alert
+            const message = ' Started background job to find label text on WSIs in this folder.';
+            let ocrImportAlertInfo = $(`<span>${message} </span>`).append($('<a/>').text('Track its progress here.').attr('href', `/#job/${resp.ocr_job}`));
+            events.once('g:alert', () => {
+                $('#g-alerts-container:last div.alert:last').append(ocrImportAlertInfo);
+            }, this);
+        }
         events.trigger('g:alert', {
             icon: 'ok',
             text: text,

--- a/wsi_deid/web_client/views/HierarchyWidget.js
+++ b/wsi_deid/web_client/views/HierarchyWidget.js
@@ -14,7 +14,7 @@ function performAction(action) {
         ingest: { done: 'Import completed.', fail: 'Failed to import.' },
         export: { done: 'Recent export task completed.', fail: 'Failed to export recent items.  Check export file location for disk drive space or other system issues.' },
         exportall: { done: 'Export all task completed.', fail: 'Failed to export all items.  Check export file location for disk drive space or other system issues.' },
-        ocrall: { fail: 'Failed to start background task to find label text for images.'}
+        ocrall: { done: 'Started background job to find label text on WSIs in this folder.', fail: 'Failed to start background task to find label text for images.'}
     };
 
     restRequest({
@@ -81,9 +81,9 @@ function performAction(action) {
             }
         }
         if (resp.action === 'ocrall') {
-            // TODO alert user with job id
-            console.log(resp);
-            return;
+            events.once('g:alert', () => {
+                $('#g-alerts-container:last div.alert:last').append($('<span> </span>')).append($('<a/>').text('Track its progress here.').attr('href', `/#job/${resp.ocrJobId}`));
+            }, this)
         }
         if (resp.fileId) {
             events.once('g:alert', () => {

--- a/wsi_deid/web_client/views/HierarchyWidget.js
+++ b/wsi_deid/web_client/views/HierarchyWidget.js
@@ -14,7 +14,7 @@ function performAction(action) {
         ingest: { done: 'Import completed.', fail: 'Failed to import.' },
         export: { done: 'Recent export task completed.', fail: 'Failed to export recent items.  Check export file location for disk drive space or other system issues.' },
         exportall: { done: 'Export all task completed.', fail: 'Failed to export all items.  Check export file location for disk drive space or other system issues.' },
-        ocrall: { done: 'Started background job to find label text on WSIs in this folder.', fail: 'Failed to start background task to find label text for images.'}
+        ocrall: { done: 'Started background job to find label text on WSIs in this folder.', fail: 'Failed to start background task to find label text for images.' }
     };
 
     restRequest({
@@ -83,7 +83,7 @@ function performAction(action) {
         if (resp.action === 'ocrall') {
             events.once('g:alert', () => {
                 $('#g-alerts-container:last div.alert:last').append($('<span> </span>')).append($('<a/>').text('Track its progress here.').attr('href', `/#job/${resp.ocrJobId}`));
-            }, this)
+            }, this);
         }
         if (resp.fileId) {
             events.once('g:alert', () => {

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -430,9 +430,9 @@ wrap(ItemView, 'render', function (render) {
                     }
                 });
             } else if (action === 'ocr') {
-                var results = '-----------------\n';
+                var results = '';
                 for (const res of resp.ocr_results.label) {
-                    results += res + '\n-----------------\n';
+                    results += res + '\n';
                 }
                 alert(results);
             } else {

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -430,7 +430,11 @@ wrap(ItemView, 'render', function (render) {
                     }
                 });
             } else if (action === 'ocr') {
-                alert(JSON.stringify(resp));
+                var results = '-----------------\n';
+                for (const res of resp.ocr_results.label) {
+                    results += res + '\n-----------------\n';
+                }
+                alert(results);
             } else {
                 this.model.fetch({ success: () => this.render() });
             }

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -357,6 +357,7 @@ wrap(ItemView, 'render', function (render) {
                 let isRedacted = redactList.images[keyname] !== undefined;
                 if (keyname !== 'label' || !settings.always_redact_label) {
                     addRedactButton(elem.find('.g-widget-auximage-title'), keyname, redactList.images[keyname], 'images', settings);
+                    addOcrButton(elem.find('.g-widget-auximage-title'), keyname, redactList.images[keyname], settings);
                 } else {
                     isRedacted = true;
                 }

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -407,6 +407,7 @@ wrap(ItemView, 'render', function (render) {
         let metadataContainer = $('.g-widget-metadata-container');
         console.log(metadataContainer);
         console.log(metadataContainer.addMetadata);
+        console.log(this.model);
     };
 
     const workflowButton = (event) => {
@@ -429,6 +430,10 @@ wrap(ItemView, 'render', function (render) {
             url: 'wsi_deid/item/' + this.model.id + '/action/' + action,
             error: null
         }).done((resp) => {
+            let alertMessage = actions[action].done;
+            if (action === 'ocr') {
+               alertMessage = `Started Job ${resp.job_id}: ${resp.job_title}.`;
+            }
             $('.g-hui-loading-overlay').remove();
             events.trigger('g:alert', {
                 icon: 'ok',
@@ -444,7 +449,8 @@ wrap(ItemView, 'render', function (render) {
                     }
                 });
             } else if (action === 'ocr') {
-                pollForOcrResults(this.model.id, addOcrMetadata, 30);
+                console.log(resp);
+                // pollForOcrResults(this.model.id, addOcrMetadata, 30);
             }else {
                 this.model.fetch({ success: () => this.render() });
             }

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -430,11 +430,11 @@ wrap(ItemView, 'render', function (render) {
                     }
                 });
             } else if (action === 'ocr') {
-                var results = '';
-                for (const res of resp.ocr_results.label) {
-                    results += res + '\n';
-                }
-                alert(results);
+                // var results = '';
+                // for (const res of resp.ocr_results.label) {
+                //     results += res + '\n';
+                // }
+                alert(JSON.stringify(resp));
             } else {
                 this.model.fetch({ success: () => this.render() });
             }

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -403,7 +403,8 @@ wrap(ItemView, 'render', function (render) {
             unquarantine: { done: 'Item unquarantined.', fail: 'Failed to unquarantine item.' },
             process: { done: 'Item redacted.', fail: 'Failed to redact item.' },
             reject: { done: 'Item rejected.', fail: 'Failed to reject item.' },
-            finish: { done: 'Item moved to approved folder.', fail: 'Failed to approve item.' }
+            finish: { done: 'Item moved to approved folder.', fail: 'Failed to approve item.' },
+            ocr: {done: 'Ran OCR.', failed: 'Failed to run OCR.'}
         };
         $('body').append(
             '<div class="g-hui-loading-overlay"><div>' +
@@ -428,6 +429,8 @@ wrap(ItemView, 'render', function (render) {
                         this.model.fetch({ success: () => this.render() });
                     }
                 });
+            } else if (action === 'ocr') {
+                alert(JSON.stringify(resp));
             } else {
                 this.model.fetch({ success: () => this.render() });
             }

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -418,7 +418,7 @@ wrap(ItemView, 'render', function (render) {
             let alertMessage = actions[action].done;
             if (action === 'ocr') {
                 events.once('g:alert', () => {
-                    $('#g-alerts-container:last div.alert:last').append($('<span> </span>')).append($('<a/>').text('Track its progress here.').attr('href', `/#job/${resp.job_id}`));
+                    $('#g-alerts-container:last div.alert:last').append($('<span> </span>')).append($('<a/>').text('Track its progress here.').attr('href', `/#job/${resp.jobId}`));
                 }, this);
             }
             $('.g-hui-loading-overlay').remove();

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -419,7 +419,7 @@ wrap(ItemView, 'render', function (render) {
             process: { done: 'Item redacted.', fail: 'Failed to redact item.' },
             reject: { done: 'Item rejected.', fail: 'Failed to reject item.' },
             finish: { done: 'Item moved to approved folder.', fail: 'Failed to approve item.' },
-            ocr: {done: 'Ran OCR.', failed: 'Failed to run OCR.'}
+            ocr: {done: 'Started job to find label text with OCR.', failed: 'Failed to start job to find label text with OCR.'}
         };
         $('body').append(
             '<div class="g-hui-loading-overlay"><div>' +
@@ -437,7 +437,7 @@ wrap(ItemView, 'render', function (render) {
             $('.g-hui-loading-overlay').remove();
             events.trigger('g:alert', {
                 icon: 'ok',
-                text: actions[action].done,
+                text: alertMessage,
                 type: 'success',
                 timeout: 4000
             });


### PR DESCRIPTION
This PR pertains to #204 
This PR adds functionality to run optical character recognition on imported images in the WSI DeID plugin. There are three ways a user can trigger this process.

1. During import
2. From the `AvailableToProcess` folder
3. On a single image in the `AvailableToProcess` folder

For (1), there is a new plugin setting to enable starting OCR during an import. To enable, navigate to `Admin console` > `Plugins` > `WSI DeID` and ensure that `Find Label Text on Import` is checked. For (2), there is a new action button next to `Import` that will trigger OCR. For (3), there is a workflow button on the item view.

All three methods will run OCR asynchronously as a local girder job. The job can be monitored from the jobs page. Any text found in the label image of a WSI is added to the item metadata for the girder item.