### PR TITLE
Allow redacting areas for associated images

### DIFF
--- a/docs/USAGE.rst
+++ b/docs/USAGE.rst
@@ -280,6 +280,8 @@ Review Process for PHI/PII in Image(s) and Metadata
 
    2.3. Scroll down to the bottom of the screen and review the associated images (label, macro, and thumbnail).  If you see PHI/PII in individual associated images, select the classification of PHI in the image from the redact control. The image will show an X through it to indicate that it will be redacted.
 
+   In addition, a button will appear with the label ``Redact Area``. Clicking on this button will allow drawing on the image in order to redact a specific region instead of the entire image. This selection can be cancelled by clicking the button again.
+
    2.4. When redaction decisions have been made for all images and metadata, the user should click the ``Redact Image`` button, which will make a copy of the existing image and place that copy in the ``Original`` folder, and will move the image to the ``Redacted`` folder. As part of moving the data to the ``Redacted`` folder, the metadata fields and associated images that have been marked for redaction will be deleted.
 
 3. If after redacting, all PHI/PII has been removed, click the green ``Approved`` button.

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'histomicsui',
         'jsonschema',
         'large_image[tiff,openslide,memcached,openjpeg]',
+        'large_image_converter',
         'openpyxl',
         'pandas',
         'paramiko',

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -278,13 +278,18 @@ def fadvise_willneed(item):
 
 
 def redact_image_area(image, geojson):
-    # TODO: implement this function
+    """
+    Redact an area from a PIL image.
+
+    :param image: a PIL image.
+    :param geojson: area to be redacted in geojson format.
+    """
     width, height = image.size
     polygon_svg = polygons_to_svg(geojson_to_polygons(geojson), width, height)
     svg_image = pyvips.Image.svgload_buffer(polygon_svg.encode())
-    memory_area = io.BytesIO()
-    image.save(memory_area, 'TIFF')
-    vips_image = pyvips.Image.new_from_buffer(memory_area.getvalue(), '')
+    buffer = io.BytesIO()
+    image.save(buffer, 'TIFF')
+    vips_image = pyvips.Image.new_from_buffer(buffer.getvalue(), '')
     logger.info(f'\n\nVIPS IMAGE\n\n{vips_image}\n\n')
     redacted_image = vips_image.composite([svg_image], pyvips.BlendMode.OVER)
     if redacted_image.bands > 3:
@@ -335,7 +340,7 @@ def redact_item(item, tempdir):
             macroImage = redact_topleft_square(macroImage)
         except Exception:
             pass
-    macro_geojson = redactList.get('image', {}).get('macro', {}).get('geojson')
+    macro_geojson = redactList.get('images', {}).get('macro', {}).get('geojson')
     if macroImage is None and macro_geojson:
         try:
             macroImage = PIL.Image.open(io.BytesIO(tileSource.getAssociatedImage('macro')[0]))

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -290,7 +290,6 @@ def redact_image_area(image, geojson):
     buffer = io.BytesIO()
     image.save(buffer, 'TIFF')
     vips_image = pyvips.Image.new_from_buffer(buffer.getvalue(), '')
-    logger.info(f'\n\nVIPS IMAGE\n\n{vips_image}\n\n')
     redacted_image = vips_image.composite([svg_image], pyvips.BlendMode.OVER)
     if redacted_image.bands > 3:
         redacted_image = redacted_image[:3]

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -322,8 +322,8 @@ def redact_item(item, tempdir):
     tileSource = ImageItem().tileSource(item)
     labelImage = None
     label_geojson = redactList.get('images', {}).get('label', {}).get('geojson')
-    if (('label' not in redactList['images'] and not config.getConfig('always_redact_label'))
-            or label_geojson is not None):
+    if (('label' not in redactList['images'] and not config.getConfig('always_redact_label')) or
+            label_geojson is not None):
         try:
             labelImage = PIL.Image.open(io.BytesIO(tileSource.getAssociatedImage('label')[0]))
         except Exception:

--- a/wsi_deid/web_client/stylesheets/ItemView.styl
+++ b/wsi_deid/web_client/stylesheets/ItemView.styl
@@ -43,6 +43,9 @@
     background linear-gradient(to top left, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) calc(50% - 4px), rgba(0, 0, 0, 1) calc(50% - 3px), rgba(0, 0, 0, 1) calc(50% + 3px), rgba(0, 0, 0, 0) calc(50% + 4px), rgba(0, 0, 0, 0) 100%), linear-gradient(to top right, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) calc(50% - 4px), rgba(0, 0, 0, 1) calc(50% - 3px), rgba(0, 0, 0, 1) calc(50% + 3px), rgba(0, 0, 0, 0) calc(50% + 4px), rgba(0, 0, 0, 0) 100%)
   .g-widget-auximage-image img
     opacity 0.5
+  .g-widget-auximage-title > .g-widget-redact-area-container
+    display inline
+    margin-left 10px
 
 
 .g-widget-auximage.redacted, .g-widget-auximage.redact-square
@@ -123,13 +126,12 @@
   padding-right 10px
 
 .g-widget-auximage-title > .g-widget-redact-area-container
-  // display inline
   display none
   margin-left 10px
 
-.g-widget-auximage.redacted .g-widget-auximage-title > .g-widget-redact-area-container
-  display inline
-  margin-left 10px
+// .g-widget-auximage.redacted .g-widget-auximage-title > .g-widget-redact-area-container
+  // display inline
+  // margin-left 10px
 
 .g-widget-redact-area-container
   button

--- a/wsi_deid/web_client/stylesheets/ItemView.styl
+++ b/wsi_deid/web_client/stylesheets/ItemView.styl
@@ -41,6 +41,7 @@
   .g-widget-auximage-image img
     opacity 0.5
 
+
 .g-widget-auximage.redacted, .g-widget-auximage.redact-square
   span.g-hui-redact-square-span
     visibility visible
@@ -84,9 +85,6 @@
   .g-widget-auximage-image-redact-square:after
     background linear-gradient(to top left, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) calc(50% - 4px), rgba(0, 0, 0, 1) calc(50% - 3px), rgba(0, 0, 0, 1) calc(50% + 3px), rgba(0, 0, 0, 0) calc(50% + 4px), rgba(0, 0, 0, 0) 100%), linear-gradient(to top right, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) calc(50% - 4px), rgba(0, 0, 0, 1) calc(50% - 3px), rgba(0, 0, 0, 1) calc(50% + 3px), rgba(0, 0, 0, 0) calc(50% + 4px), rgba(0, 0, 0, 0) 100%)
 
-.g-widget-auximage-title > .g-widget-redact-area-container
-  display inline
-
 .g-widget-metadata-container.workflow .g-workflow-button
   margin 10px
 
@@ -121,6 +119,15 @@
   float right
   padding-right 10px
 
+.g-widget-auximage-title > .g-widget-redact-area-container
+  // display inline
+  display none
+  margin-left 10px
+
+.g-widget-auximage.redacted .g-widget-auximage-title > .g-widget-redact-area-container
+  display inline
+  margin-left 10px
+
 .g-widget-redact-area-container
   button
     padding 3px 5px
@@ -144,3 +151,6 @@
       display unset
   select.g-hui-redact
     visibility unset
+
+.no-disp
+  display none

--- a/wsi_deid/web_client/stylesheets/ItemView.styl
+++ b/wsi_deid/web_client/stylesheets/ItemView.styl
@@ -129,10 +129,6 @@
   display none
   margin-left 10px
 
-// .g-widget-auximage.redacted .g-widget-auximage-title > .g-widget-redact-area-container
-  // display inline
-  // margin-left 10px
-
 .g-widget-redact-area-container
   button
     padding 3px 5px

--- a/wsi_deid/web_client/stylesheets/ItemView.styl
+++ b/wsi_deid/web_client/stylesheets/ItemView.styl
@@ -13,7 +13,8 @@
   display none
 
 .wsi-deid-auximage-container
-  display block
+  display inline-block
+  vertical-align middle
 
 .large_image_metadata_value.redacted
   text-decoration-line line-through

--- a/wsi_deid/web_client/stylesheets/ItemView.styl
+++ b/wsi_deid/web_client/stylesheets/ItemView.styl
@@ -84,6 +84,9 @@
   .g-widget-auximage-image-redact-square:after
     background linear-gradient(to top left, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) calc(50% - 4px), rgba(0, 0, 0, 1) calc(50% - 3px), rgba(0, 0, 0, 1) calc(50% + 3px), rgba(0, 0, 0, 0) calc(50% + 4px), rgba(0, 0, 0, 0) 100%), linear-gradient(to top right, rgba(0, 0, 0, 0) 0, rgba(0, 0, 0, 0) calc(50% - 4px), rgba(0, 0, 0, 1) calc(50% - 3px), rgba(0, 0, 0, 1) calc(50% + 3px), rgba(0, 0, 0, 0) calc(50% + 4px), rgba(0, 0, 0, 0) 100%)
 
+.g-widget-auximage-title > .g-widget-redact-area-container
+  display inline
+
 .g-widget-metadata-container.workflow .g-workflow-button
   margin 10px
 

--- a/wsi_deid/web_client/stylesheets/ItemView.styl
+++ b/wsi_deid/web_client/stylesheets/ItemView.styl
@@ -13,7 +13,7 @@
   display none
 
 .wsi-deid-auximage-container
-  display inline
+  display block
 
 .large_image_metadata_value.redacted
   text-decoration-line line-through

--- a/wsi_deid/web_client/stylesheets/ItemView.styl
+++ b/wsi_deid/web_client/stylesheets/ItemView.styl
@@ -12,6 +12,9 @@
 .wsi-deid-replace-value
   display none
 
+.wsi-deid-auximage-container
+  display inline
+
 .large_image_metadata_value.redacted
   text-decoration-line line-through
   text-decoration-color black

--- a/wsi_deid/web_client/templates/ItemViewRedactArea.pug
+++ b/wsi_deid/web_client/templates/ItemViewRedactArea.pug
@@ -1,5 +1,5 @@
 .g-widget-redact-area-container
-  button.h-draw.btn.btn-sm.btn-default(type='button', title='Draw an area to redact or clear the existing area')
+  button.h-draw.btn.btn-sm.btn-default(type='button', title='Draw an area to redact or clear the existing area', keyname=keyname)
     span.redact-area
       i.icon-check-empty
       | Redact Area

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -318,25 +318,25 @@ wrap(ItemView, 'render', function (render) {
                 return true;
             }
             let mapId = `${keyname}-map`;
-            let tilesPath = `/api/v1/item/${this.model.id}/tiles`;
+            let tilesPath = `item/${this.model.id}/tiles`;
             let mapDiv = $(`<div id="${mapId}" class="wsi-deid-associated-image-map"></div>`);
             elem.after(mapDiv);
 
-            fetch(`${tilesPath}/images/${keyname}/metadata`)
-                .then((response) => response.json())
-                .then((imageInfo) => {
-                    let params = window.geo.util.pixelCoordinateParams(
-                        `#${mapId}`, imageInfo.sizeX, imageInfo.sizeY, imageInfo.sizeX, imageInfo.sizeY);
-                    $(`#${mapId}`).width(imageInfo.sizeX * 1.1).height(imageInfo.sizeY * 1.1);
-                    const map = window.geo.map(params.map);
-                    params.layer.url = `${tilesPath}/images/${keyname}`;
-                    map.createLayer('osm', params.layer);
-                    map.geoOn(window.geo.event.mouseclick, function (evt) {
-                        console.log(`Clicked the ${keyname} map`);
-                    });
-                    imageElem.remove();
-                    return null;
+            restRequest({
+                url: `${tilesPath}/images/${keyname}/metadata`,
+                error: null
+            }).done((resp) => {
+                let params = window.geo.util.pixelCoordinateParams(
+                    `#${mapId}`, resp.sizeX, resp.sizeY, resp.sizeX, resp.sizeY);
+                $(`#${mapId}`).width(resp.sizeX * 1.1).height(resp.sizeY * 1.1);
+                const map = window.geo.map(params.map);
+                params.layer.url = `/api/v1/${tilesPath}/images/${keyname}`;
+                map.createLayer('osm', params.layer);
+                map.geoOn(window.geo.event.mouseclick, function (evt) {
+                    console.log(`Clicked the ${keyname} map`);
                 });
+                imageElem.remove();
+            });
         });
     };
 

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -240,7 +240,11 @@ wrap(ItemView, 'render', function (render) {
             });
             elem = $('<span class="g-hui-redact-label"></span>').append(elem);
         }
-        parentElem.append(elem);
+        if (['label', 'macro'].includes(keyname)) {
+            const redactArea = ItemViewRedactAreaTemplate({ keyname: keyname });
+            this.events['click .g-widget-auximage-title .g-widget-redact-area-container button'] = redactAreaAuxImage;
+            parentElem.append(elem).append(redactArea);
+        }
     };
 
     const addNewValueEntryField = (parentElem, keyname, redactRecord, settings) => {
@@ -314,6 +318,7 @@ wrap(ItemView, 'render', function (render) {
             let imageElem = elem.find('.g-widget-auximage-image');
             elem.wrap($('<div class="wsi-deid-auximage-container"></div>'));
             let keyname = elem.attr('auximage');
+            // (WIP) Don't include label if the settings dictate to always redact label
             if (!['label', 'macro'].includes(keyname)) {
                 return true;
             }
@@ -517,6 +522,12 @@ wrap(ItemView, 'render', function (render) {
         this.putRedactList(redactList, 'handleWSIAnnotationMode');
         this.$el.find('.g-widget-redact-area-container button').removeClass('active');
         this.$el.find('.g-widget-redact-area-container').removeClass('area-adding').toggleClass('area-set', !!redactList.area._wsi);
+    };
+
+    const redactAreaAuxImage = (event) => {
+        event.stopPropagation();
+        console.log(event);
+        return false;
     };
 
     const redactAreaWSI = (event) => {

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -345,7 +345,9 @@ wrap(ItemView, 'render', function (render) {
                 try {
                     let params = window.geo.util.pixelCoordinateParams(
                         `#${mapId}`, resp.sizeX, resp.sizeY, resp.sizeX, resp.sizeY);
-                    $(`#${mapId}`).width(resp.sizeX * 1.1).height(resp.sizeY * 1.1);
+                    let imgH = imageElem.height();
+                    let imgW = imageElem.width();
+                    $(`#${mapId}`).width(imgW).height(imgH);
                     const map = window.geo.map(params.map);
                     auxImageMaps[keyname] = map;
                     params.layer.url = `/api/v1/${tilesPath}/images/${keyname}`;

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -526,17 +526,23 @@ wrap(ItemView, 'render', function (render) {
         return map.layers().filter((l) => l instanceof window.geo.annotationLayer)[0];
     };
 
-    const toggleAuxImageMapDisplay = (map, image, showMap) => {
-        // Toggle showing the image or a geojs map of the image.
-        // If redacting the whole image or top/right square, no need to show the map.
-        // param 'map' should be the container of the geojs map
-        // param 'image' should be the container of the associated image
+    /**
+     * Toggle showing the image or a geojs map of the image.
+     * If redacting the whole image or top/right square, no need to show the map.
+     * @param {object} mapContainer The container element of the geojs map to show/hide
+     * @param {object} imageContainer The container element of the associated image to show/hide
+     * @param {boolean} showMap Truthy to show the map and hide the image, falsy to hide the map and show the original image
+     */
+    const toggleAuxImageMapDisplay = (mapContainer, imageContainer, showMap) => {
         if (showMap) {
-            map.removeClass('no-disp');
-            image.addClass('no-disp');
+            // adjust height and width of map, since they may be wrong on initial load of an image
+            mapContainer.height(imageContainer.height());
+            mapContainer.width(imageContainer.width());
+            mapContainer.removeClass('no-disp');
+            imageContainer.addClass('no-disp');
         } else {
-            map.addClass('no-disp');
-            image.removeClass('no-disp');
+            mapContainer.addClass('no-disp');
+            imageContainer.removeClass('no-disp');
         }
     };
 

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -246,6 +246,8 @@ wrap(ItemView, 'render', function (render) {
             const redactArea = ItemViewRedactAreaTemplate({ keyname: keyname });
             this.events['click .g-widget-auximage-title .g-widget-redact-area-container button'] = redactAreaAuxImage;
             parentElem.append(elem).append(redactArea);
+        } else {
+            parentElem.append(elem);
         }
     };
 
@@ -314,8 +316,7 @@ wrap(ItemView, 'render', function (render) {
         window.setTimeout(() => resizeRedactBackground(elem), 1000);
     };
 
-    const addAssociatedImageMaps = (settings) => {
-        const redactList = this.getRedactList();
+    const addAssociatedImageMaps = (settings, redactList) => {
         this.$el.find('.g-widget-metadata-container.auximage .g-widget-auximage').each((idx, elem) => {
             elem = $(elem);
             let imageElem = elem.find('.g-widget-auximage-image');
@@ -442,6 +443,9 @@ wrap(ItemView, 'render', function (render) {
                 }
                 elem.toggleClass('redacted', isRedacted && !redactSquare);
             });
+            if (showControls) {
+                addAssociatedImageMaps(settings, redactList);
+            }
             this.events['input .g-hui-redact'] = flagRedaction;
             this.events['change .g-hui-redact'] = flagRedaction;
             this.events['click a.g-hui-redact'] = flagRedaction;
@@ -652,10 +656,6 @@ wrap(ItemView, 'render', function (render) {
     const adjustControls = (folderType, settings) => {
         let hasRedactionControls = (folderType === 'ingest' || folderType === 'quarantine');
         addRedactionControls(hasRedactionControls, settings || {});
-        console.log(`Has controls: ${hasRedactionControls}`);
-        if (hasRedactionControls) {
-            addAssociatedImageMaps(settings || {});
-        }
         /* Start with the metadata section collapsed */
         this.$el.find('.g-widget-metadata-header:first').attr({ 'data-toggle': 'collapse', 'data-target': '.g-widget-metadata-container:first' });
         this.$el.find('.g-widget-metadata-container:first').addClass('collapse');

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -546,6 +546,17 @@ wrap(ItemView, 'render', function (render) {
         }
     };
 
+    /**
+     * Helper function to toggle the display and remove checked status of the redact square control for macro images.
+     * @param {boolean} showControl True to show the 'redact square' control, false to hide it
+     */
+    const toggleRedactSquareControlDisplay = (showControl) => {
+        let redactSquareSpan = this.$el.find('.g-hui-redact-square-span');
+        let redactSquareInput = redactSquareSpan.find('.g-hui-redact-square');
+        redactSquareInput.prop('checked', false);
+        redactSquareSpan.toggleClass('no-disp', !showControl);
+    };
+
     const handleAuxImageAnnotationMode = (event) => {
         const eventMap = event.geo._triggeredBy;
         const annLayer = eventMap.layers().filter((l) => l instanceof window.geo.annotationLayer)[0];
@@ -617,10 +628,10 @@ wrap(ItemView, 'render', function (render) {
         const map = auxImageMaps[keyname];
         const imageElem = this.$el.find(`.g-widget-metadata-container.auximage .wsi-deid-auximage-container .g-widget-auximage[auximage=${keyname}] .g-widget-auximage-image img`);
         const annLayer = map.layers().filter((l) => l instanceof window.geo.annotationLayer)[0];
+        let redactList = this.getRedactList();
         if (buttonContainer.hasClass('area-set') || buttonContainer.hasClass('area-adding')) {
             clickedButton.removeClass('active');
             buttonContainer.removeClass('area-set').removeClass('area-adding');
-            let redactList = this.getRedactList();
             redactList.images = redactList.images || {};
             delete redactList.images[keyname].geojson;
             this.putRedactList(redactList, 'redactAreaAuxImage');
@@ -630,10 +641,20 @@ wrap(ItemView, 'render', function (render) {
                 annLayer.mode(null);
             }
             toggleAuxImageMapDisplay(map.node(), imageElem.parent(), false);
+            if (keyname === 'macro') {
+                toggleRedactSquareControlDisplay(true);
+            }
             return false;
         }
 
         toggleAuxImageMapDisplay(map.node(), imageElem.parent(), true);
+        if (keyname === 'macro') {
+            toggleRedactSquareControlDisplay(false);
+            redactList.images = redactList.images || {};
+            if (redactList.images[keyname]) {
+                delete redactList.images[keyname]['square'];
+            }
+        }
         annLayer.options('clickToEdit', true);
         annLayer.mode('polygon');
         clickedButton.addClass('active');

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -343,11 +343,11 @@ wrap(ItemView, 'render', function (render) {
                 error: null
             }).done((resp) => {
                 try {
-                    let params = window.geo.util.pixelCoordinateParams(
-                        `#${mapId}`, resp.sizeX, resp.sizeY, resp.sizeX, resp.sizeY);
                     let imgH = imageElem.height();
                     let imgW = imageElem.width();
                     $(`#${mapId}`).width(imgW).height(imgH);
+                    let params = window.geo.util.pixelCoordinateParams(
+                        `#${mapId}`, resp.sizeX, resp.sizeY, resp.sizeX, resp.sizeY);
                     const map = window.geo.map(params.map);
                     auxImageMaps[keyname] = map;
                     params.layer.url = `/api/v1/${tilesPath}/images/${keyname}`;

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -652,7 +652,10 @@ wrap(ItemView, 'render', function (render) {
     const adjustControls = (folderType, settings) => {
         let hasRedactionControls = (folderType === 'ingest' || folderType === 'quarantine');
         addRedactionControls(hasRedactionControls, settings || {});
-        addAssociatedImageMaps(settings);
+        console.log(`Has controls: ${hasRedactionControls}`);
+        if (hasRedactionControls) {
+            addAssociatedImageMaps(settings || {});
+        }
         /* Start with the metadata section collapsed */
         this.$el.find('.g-widget-metadata-header:first').attr({ 'data-toggle': 'collapse', 'data-target': '.g-widget-metadata-container:first' });
         this.$el.find('.g-widget-metadata-container:first').addClass('collapse');


### PR DESCRIPTION
Closes #180 

This PR adds the ability for end users to redact parts of label and macro images by drawing polygons on those images.

Summary of technical changes:
- Upon loading the item view, create GeoJS maps for label/macro images
- Add event handling to enable redacting areas of associated images, including updating the `redactList` with geojson
- Add styles to hide/show the map as needed
- Use `pyvips` and `PIL` to black out selected regions on the back end during item redaction

Workflow changes:
- Upon selecting a reason for redacting either a label or macro image, a button will appear, giving the option to redact an area
- If a user clicks on this button, the image is replaces by a GeoJS map, which the user can draw polygons on
- The button functions the same as the button for the whole slide image, in that the user can cancel or clear their selection
- If the user cancels the selection or decides not to redact the image, the map is hidden and the image is shown