### PR TITLE
Pin a version to avoid an issue with the rsvg library.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'pandas',
         'paramiko',
         'python-magic',
+        'pyvips!=2.1.16',
         'xlrd',
     ],
     license='Apache Software License 2.0',

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,11 @@ install_command = pip install --find-links https://girder.github.io/large_image_
 whitelist_externals =
   rm
   npx
+  curl
 commands =
   rm -rf .tox/test/coverage/web_temp
   girder build --dev
+  curl https://github.com/OpenGeoscience/geojs/releases/download/v1.5.0/geo.js -Lo {envdir}/share/girder/static/built/plugins/large_image/extra/geojs.js
   pytest --cov {envsitepackagesdir}/wsi_deid {posargs}
   npx nyc report --temp-dir build/test/coverage/web_temp --report-dir .tox/coverage --reporter cobertura --reporter text-summary
 # Reduce npm chatter


### PR DESCRIPTION
Recently, rsvg limited the size of svgs.  We need to change to using tiled generation, but in the mean time, pin to the last version that worked as expected.