### PR TITLE
Switch to Ubuntu 20.04 as the base.

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,7 +1,7 @@
 # bash: Default CMD is not bash
 CVE-2019-18276
 
-# coreutils: Not explicitly using chroot in coreutils 
+# coreutils: Not explicitly using chroot in coreutils
 CVE-2016-2781
 
 # gcc-8-base: Not building for ARM
@@ -69,9 +69,11 @@ CVE-2022-0368
 CVE-2022-0392
 CVE-2022-0408
 CVE-2022-0413
+CVE-2022-0417
 CVE-2022-0443
 CVE-2022-0554
 CVE-2022-0572
+CVE-2022-0629
 CVE-2022-0685
 CVE-2022-0714
 CVE-2022-0729
@@ -102,12 +104,15 @@ CVE-2022-2183
 CVE-2022-2206
 CVE-2022-2304
 CVE-2022-2343
+CVE-2022-2344
 CVE-2022-2345
+CVE-2022-2571
 CVE-2022-2581
 CVE-2022-2845
 CVE-2022-2849
 CVE-2022-2923
 CVE-2022-2946
+CVE-2022-2980
 
 # Python mailcap not used with our code
 CVE-2015-20107

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 
 # See logs faster; don't write pyc or pyo files
@@ -6,15 +6,13 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata && \
+    # DEBIAN_FRONTEND=noninteractive apt-get install -qy tzdata && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --yes \
     software-properties-common \
-    gpg-agent \
+    # gpg-agent \
     fonts-dejavu \
     libmagic-dev \
     git \
-    # libldap2-dev \
-    # libsasl2-dev \
     curl \
     ca-certificates \
     vim \


### PR DESCRIPTION
This increases the docker size slightly, but reduces the reported security concerns.