### PR TITLE
Add the import button to the Unfiled folder.

### DIFF
--- a/wsi_deid/web_client/views/HierarchyWidget.js
+++ b/wsi_deid/web_client/views/HierarchyWidget.js
@@ -222,6 +222,15 @@ function addControls(key, settings) {
                 action: 'list/process',
                 check: () => settings.show_metadata_in_lists
             }
+        ],
+        unfiled: [
+            {
+                key: 'import',
+                text: 'Import',
+                class: 'btn-info',
+                action: 'ingest',
+                check: () => settings.show_import_button !== false
+            }
         ]
     };
     if (!controls[key]) {


### PR DESCRIPTION
Since when we import files that can be filed in the AvailableToProcess folder, having import in both places makes sense.