### PR TITLE
Link to item page of import/export summary report

### DIFF
--- a/wsi_deid/import_export.py
+++ b/wsi_deid/import_export.py
@@ -603,7 +603,7 @@ def reportSummary(*args, **kwargs):
     :param **kwargs: if 'file' is specified, this is a Girder file model.  The
         file id is returned as part of the results.
     :returns: a dictionary of status values, each with a numerical tally, and
-        optionally a fileId field.
+        optionally a reportItemId field.
     """
     result = {}
     for report in args:
@@ -611,7 +611,7 @@ def reportSummary(*args, **kwargs):
             result.setdefault(entry['status'], 0)
             result[entry['status']] += 1
     if kwargs.get('file'):
-        result['fileId'] = str(kwargs['file']['_id'])
+        result['reportItemId'] = str(kwargs['file']['itemId'])
     return result
 
 

--- a/wsi_deid/web_client/views/HierarchyWidget.js
+++ b/wsi_deid/web_client/views/HierarchyWidget.js
@@ -133,9 +133,9 @@ function performAction(action) {
                 text = 'No new items without existing label text metadata.';
             }
         }
-        if (resp.fileId) {
+        if (resp.reportItemId) {
             events.once('g:alert', () => {
-                $('#g-alerts-container:last div.alert:last').append($('<span> </span>')).append($('<a/>').text('See the Excel report for more details.').attr('href', `/api/v1/file/${resp.fileId}/download`));
+                $('#g-alerts-container:last div.alert:last').append($('<span> </span>')).append($('<a/>').text('See the Excel report for more details.').attr('href', `/#item/${resp.reportItemId}`));
             }, this);
         }
         if (resp['sftp_enabled']) {


### PR DESCRIPTION
Resolves #311 

After the user triggers an import or export of data from the WSI DeID collection, the get an alert from girder containing a link to an import or export report. Previously that link would trigger a download of the generated excel file.

Now that excel files are viewable within girder itself, the link has been updated to take the user to the item page for the report. From the item page, the user can view rows of the report, as well as download the spreadsheet if they so choose. 