### PR TITLE
Add settings for PHI/PII choices

### DIFF
--- a/devops/wsi_deid/girder.local.conf
+++ b/devops/wsi_deid/girder.local.conf
@@ -81,3 +81,20 @@ reject_reasons = [{
         { "key": "Out_Of_Focus", "text": "Out of focus" },
         { "key": "Low_Resolution", "text": "Low resolution" },
         { "key": "Other_Image_Quality", "text": "Other" }]}]
+phi_pii_types = [{
+    "category": "Personal_Info",
+    "text": "Personal Information",
+    "types": [
+        { "key": "Patient_Name", "text": "Patient Name" },
+        { "key": "Patient_DOB", "text": "Date of Birth " },
+        { "key": "SSN", "text": "Social Security Number" },
+        { "key": "Other_Personal", "text": "Other Personal" }]}, {
+    "category": "Demographics",
+    "key": "Demographics",
+    "text": "Demographics"}, {
+    "category": "Facility_Physician",
+    "key": "Facility_Physician",
+    "text": "Facility/Physician Information"}, {
+    "category": "Other_PHIPII",
+    "key": "Other_PHIPII",
+    "text": "Other PHI/PII"}]

--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -22,6 +22,8 @@ Redaction Categories
 
 By default, when metadata or images are redacted, the user must pick the type of PHI/PII that is present and the reason for the redaction.  If the ``require_redact_category`` is set to ``False``, then, instead of requiring a reason, the user interface will show a ``REDACT`` button that toggles redaction on and off for the metadata or image.  The export file will contain ``No Reason Collected`` in these cases.
 
+Redaction categories can be configured by changing the ``phi_pii_types`` settings.
+
 Reasons for Rejection
 +++++++++++++++++++++
 

--- a/docs/USAGE.rst
+++ b/docs/USAGE.rst
@@ -372,6 +372,8 @@ The table below describes the redaction options and definitions of PHI/PII categ
 
 ``*`` For these dates, year is permissible; however, full or partial date including the day and/or month is considered PHI/PII.
 
+See `CUSTOMIZING.rst <CUSTOMIZING.rst>`_ for information on customizing the PHI/PII types that can be selected.
+
 Exporting Data
 ==============
 

--- a/wsi_deid/config.py
+++ b/wsi_deid/config.py
@@ -81,7 +81,34 @@ defaultConfig = {
             {'key': 'Low_Resolution', 'text': 'Low resolution'},
             {'key': 'Other_Image_Quality', 'text': 'Other'}
         ]
-    }]
+    }],
+    'phi_pii_types': [
+        {
+            'category': 'Personal_Info',
+            'text': 'Personal Information',
+            'types': [
+                {'key': 'Patient_Name', 'text': 'Patient Name'},
+                {'key': 'Patient_DOB', 'text': 'Date of Birth '},
+                {'key': 'SSN', 'text': 'Social Security Number'},
+                {'key': 'Other_Personal', 'text': 'Other Personal'}
+            ]
+        },
+        {
+            'category': 'Demographics',
+            'key': 'Demographics',
+            'text': 'Demographics'
+        },
+        {
+            'category': 'Facility_Physician',
+            'key': 'Facility_Physician',
+            'text': 'Facility/Physician Information'
+        },
+        {
+            'category': 'Other_PHIPII',
+            'key': 'Other_PHIPII',
+            'text': 'Other PHI/PII'
+        }
+    ]
 }
 
 

--- a/wsi_deid/web_client/utils.js
+++ b/wsi_deid/web_client/utils.js
@@ -12,29 +12,6 @@ const formats = {
     none: ''
 };
 
-const PHIPIITypes = [{
-    category: 'Personal_Info',
-    text: 'Personal Information',
-    types: [
-        { key: 'Patient_Name', text: 'Patient Name' },
-        { key: 'Patient_DOB', text: 'Date of Birth ' },
-        { key: 'SSN', text: 'Social Security Number' },
-        { key: 'Other_Personal', text: 'Other Personal' }
-    ]
-}, {
-    category: 'Demographics',
-    key: 'Demographics',
-    text: 'Demographics'
-}, {
-    category: 'Facility_Physician',
-    key: 'Facility_Physician',
-    text: 'Facility/Physician Information'
-}, {
-    category: 'Other_PHIPII',
-    key: 'Other_PHIPII',
-    text: 'Other PHI/PII'
-}];
-
 
 const systemRedactedReason = 'System Redacted';
 
@@ -243,7 +220,6 @@ function flagRedactionOnItem(itemModel, event) {
 
 export {
     formats,
-    PHIPIITypes,
     systemRedactedReason,
 
     flagRedactionOnItem,

--- a/wsi_deid/web_client/views/ItemList.js
+++ b/wsi_deid/web_client/views/ItemList.js
@@ -8,8 +8,7 @@ import ItemListWidget from '@girder/large_image/views/itemList';
 
 import {
     formats, flagRedactionOnItem, getRedactList, getRedactionDisabledPatterns,
-    getHiddenMetadataPatterns, matchFieldPattern, systemRedactedReason,
-    PHIPIITypes
+    getHiddenMetadataPatterns, matchFieldPattern, systemRedactedReason
 } from '../utils';
 
 import '../stylesheets/ItemList.styl';
@@ -89,6 +88,7 @@ wrap(ItemListWidget, 'initialize', function (initialize) {
             info._visible = info._visible.filter((keylist) => info._redactable.indexOf(keylist) < 0);
             info._visible.sort();
             this._wsi_deid_item_list = info;
+            this.phiPiiTypes = info.wsi_deid_settings.phi_pii_types;
             this.render();
         });
     };
@@ -193,7 +193,7 @@ wrap(ItemListWidget, 'render', function (render) {
         info: this._wsi_deid_item_list,
         hasRedactionControls: (this._folderKey === 'ingest' || this._folderKey === 'quarantine'),
         systemRedactedReason: systemRedactedReason,
-        PHIPIITypes: PHIPIITypes,
+        PHIPIITypes: this.phiPiiTypes,
         showAllVisible: false
     }));
     var parent = this.$el;

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -15,7 +15,7 @@ import ItemViewRedactAreaTemplate from '../templates/ItemViewRedactArea.pug';
 import '../stylesheets/ItemView.styl';
 import {
     formats, getRedactList, putRedactList, goToNextUnprocessedItem,
-    PHIPIITypes, getHiddenMetadataPatterns, getRedactionDisabledPatterns,
+    getHiddenMetadataPatterns, getRedactionDisabledPatterns,
     matchFieldPattern, flagRedactionOnItem, systemRedactedReason
 } from '../utils';
 
@@ -52,7 +52,8 @@ wrap(ItemView, 'render', function (render) {
             });
             elem.append($('<option value="none">Keep (do not redact)</option>'));
             let matched = false;
-            PHIPIITypes.forEach((cat) => {
+            const phiPiiTypes = settings.phi_pii_types;
+            phiPiiTypes.forEach((cat) => {
                 if (cat.types) {
                     let optgroup = $('<optgroup/>');
                     optgroup.attr({ label: cat.text });


### PR DESCRIPTION
Resolves #319 

PHI/PII type is now a configurable settings. Previously it was defined in `utils.js` and accessed by `ItemView.js` and `ListView.js` for building the redaction reason select.

Now, the plugin settings include `phi_pii_types`, and a default which matches was was previously defined. The default is mirrored in `config.py`. Documentation has been updated to state that the PHI/PII type list can be changed.