### PR TITLE
Add tests for unfiled images using default schema

### DIFF
--- a/tests/data/default_schema_deidUpload.csv
+++ b/tests/data/default_schema_deidUpload.csv
@@ -1,0 +1,5 @@
+TokenID,SurgPathNum,Registry,First_Name,Last_Name,Date_of_Birth_mmddyyyy,Tumor_Rec_Number,Histology_Code,Behavior_Code
+0590XY112001,S16-1234,66,Natalina,Eltun,12012008,01,9440,3
+0590XY112002,C17-3456,66,Moria,Sterman,12012009,01,9440,3
+0590XY112003,C16-9876,66,Aila,Neles,11012009,01,9530,3
+0590XY112004,S17-3421,66,Shaylah,Hardacre,12012009,01,9440,3

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -14,6 +14,14 @@ registry = {
     'philips.ptif': 'sha512:ec0ec688537080e4ec2abb3978c14577df87250a2c0af42beaadc8f00f0baba210997d5d2fe7cfeeceb841885b6adad0c9f607e35eddcc479eb487bd3c1e28ac',  # noqa
 }
 
+default_registry = {
+    'SEER_Mouse_1_17158539.svs': 'sha512:1ace33abb4bf96382c8823706c43deb1115b08d46bf96e2b03f425697a85e767631f0dc5568cce68c9110f1df66d264a97671fd488466f3cf59295513d6c7792', # noqa
+    'SEER_Mouse_1_17158540.svs': 'sha512:74a0d97e9f8e3f42409c10be37eca9fb5d3be06f0a4f258d4b58efb5adc67f3f787a868bce6aa75649d25b221f4a0b32109bcc1ca1c696d4060981cb7d6b65f1', # noqa
+    'SEER_Mouse_1_17158541.svs': 'sha512:f5fcbc5f31201ff7a28886d2b386a34fe9c0eb84cf9ce4e30601e6abe43c120ed242e23b1af555e69abab7823aef59a7220e6159b12f2cf565a2de69eb2cf1cb', # noqa
+    'SEER_Mouse_1_17158542.svs': 'sha512:e763630a72b307932c64e442253fbf3c1877e7c9db77abb93864d37418fe7f94b9ace5286dff44ff0242ca1acfc58e3282b71959a864abdd925dc409452e40b7', # noqa
+    'SEER_Mouse_1_17158543.svs': 'sha512:60ef06d11da310b713327adcab122e128a8a9506a68047dcff3ac5a327766e168f97ec032ba92b997b0d83e455864f8f61998c8c5f24767471b8b3c951838de1'  # noqa
+}
+
 
 class DKCPooch(pooch.Pooch):
     def get_url(self, fname):
@@ -28,4 +36,12 @@ datastore = DKCPooch(
     ),
     base_url='https://data.kitware.com/api/v1/file/hashsum/{algo}/{hashvalue}/download',
     registry=registry,
+)
+
+lowres_datastore = DKCPooch(
+    path=pooch.utils.cache_location(
+        os.path.join(os.environ.get('TOX_WORK_DIR', pooch.utils.os_cache('pooch')), 'dkc_datastore')
+    ),
+    base_url='https://data.kitware.com/api/v1/file/hashsum/{algo}/{hashvalue}/download',
+    registry=default_registry
 )

--- a/tests/datastore.py
+++ b/tests/datastore.py
@@ -12,9 +12,7 @@ registry = {
     # Philips file
     # Source: sample_image.ptif
     'philips.ptif': 'sha512:ec0ec688537080e4ec2abb3978c14577df87250a2c0af42beaadc8f00f0baba210997d5d2fe7cfeeceb841885b6adad0c9f607e35eddcc479eb487bd3c1e28ac',  # noqa
-}
-
-default_registry = {
+    # Sample mouse tissue files to use with default schema tests
     'SEER_Mouse_1_17158539.svs': 'sha512:1ace33abb4bf96382c8823706c43deb1115b08d46bf96e2b03f425697a85e767631f0dc5568cce68c9110f1df66d264a97671fd488466f3cf59295513d6c7792', # noqa
     'SEER_Mouse_1_17158540.svs': 'sha512:74a0d97e9f8e3f42409c10be37eca9fb5d3be06f0a4f258d4b58efb5adc67f3f787a868bce6aa75649d25b221f4a0b32109bcc1ca1c696d4060981cb7d6b65f1', # noqa
     'SEER_Mouse_1_17158541.svs': 'sha512:f5fcbc5f31201ff7a28886d2b386a34fe9c0eb84cf9ce4e30601e6abe43c120ed242e23b1af555e69abab7823aef59a7220e6159b12f2cf565a2de69eb2cf1cb', # noqa
@@ -36,12 +34,4 @@ datastore = DKCPooch(
     ),
     base_url='https://data.kitware.com/api/v1/file/hashsum/{algo}/{hashvalue}/download',
     registry=registry,
-)
-
-lowres_datastore = DKCPooch(
-    path=pooch.utils.cache_location(
-        os.path.join(os.environ.get('TOX_WORK_DIR', pooch.utils.os_cache('pooch')), 'dkc_datastore')
-    ),
-    base_url='https://data.kitware.com/api/v1/file/hashsum/{algo}/{hashvalue}/download',
-    registry=default_registry
 )

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from pytest_girder.web_client import runWebClientTest
 
-from .utilities import provisionDefaultSchemaBoundServer, provisionBoundServer, resetConfig  # noqa
+from .utilities import provisionBoundServer, provisionDefaultSchemaBoundServer, resetConfig  # noqa
 
 
 @pytest.mark.plugin('wsi_deid')

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from pytest_girder.web_client import runWebClientTest
 
-from .utilities import provisionBoundServer, resetConfig  # noqa
+from .utilities import provisionDefaultSchemaBoundServer, provisionBoundServer, resetConfig  # noqa
 
 
 @pytest.mark.plugin('wsi_deid')
@@ -17,3 +17,16 @@ def testWebClient(boundServer, db, spec, provisionBoundServer, resetConfig):  # 
         os.path.dirname(wsi_deid.import_export.SCHEMA_FILE_PATH), 'importManifestSchema.test.json')
     spec = os.path.join(os.path.dirname(__file__), '..', 'wsi_deid', 'web_client', 'tests', spec)
     runWebClientTest(boundServer, spec, 15000)
+
+
+@pytest.mark.plugin('wsi_deid')
+@pytest.mark.parametrize('spec', (
+    'wsi_deidDefaultSchemaSpec.js',
+))
+def testDefaultSchemaWebClient(boundServer, db, spec, provisionDefaultSchemaBoundServer, mocker): # noqa
+    def mockStartOcrForUnfiled(*args):
+        return None
+
+    mocker.patch('wsi_deid.import_export.startOcrJobForUnfiled', mockStartOcrForUnfiled)
+    specPath = os.path.join(os.path.dirname(__file__), '..', 'wsi_deid', 'web_client', 'tests', spec)
+    runWebClientTest(boundServer, specPath, 15000)

--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -28,5 +28,11 @@ def testDefaultSchemaWebClient(boundServer, db, spec, provisionDefaultSchemaBoun
         return None
 
     mocker.patch('wsi_deid.import_export.startOcrJobForUnfiled', mockStartOcrForUnfiled)
-    specPath = os.path.join(os.path.dirname(__file__), '..', 'wsi_deid', 'web_client', 'tests', spec)
+    specPath = os.path.join(
+        os.path.dirname(__file__),
+        '..', 'wsi_deid',
+        'web_client',
+        'tests',
+        spec
+    )
     runWebClientTest(boundServer, specPath, 15000)

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -25,6 +25,11 @@ def provisionDefaultSchemaServer(server, admin, fsAssetstore, tmp_path):
     yield _provisionDefaultSchemaServer(tmp_path)
 
 
+@pytest.fixture
+def provisionDefaultSchemaBoundServer(boundServer, admin, fsAssetstore, tmp_path):
+    yield _provisionDefaultSchemaServer(tmp_path)
+
+
 def _provisionServer(tmp_path):
     sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'devops', 'wsi_deid'))
     import provision  # noqa

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -7,7 +7,7 @@ from girder.models.setting import Setting
 
 from wsi_deid.constants import PluginSettings
 
-from .datastore import datastore
+from .datastore import datastore, lowres_datastore
 
 
 @pytest.fixture
@@ -18,6 +18,11 @@ def provisionServer(server, admin, fsAssetstore, tmp_path):
 @pytest.fixture
 def provisionBoundServer(boundServer, admin, fsAssetstore, tmp_path):
     yield _provisionServer(tmp_path)
+
+
+@pytest.fixture
+def provisionDefaultSchemaServer(server, admin, fsAssetstore, tmp_path):
+    yield _provisionDefaultSchemaServer(tmp_path)
 
 
 def _provisionServer(tmp_path):
@@ -51,3 +56,47 @@ def resetConfig():
     # Use default wsi_deid config for tests
     config = girder.utility.config.getConfig()
     config[wsi_deid.config.CONFIG_SECTION] = {}
+
+
+@pytest.fixture
+def _provisionDefaultSchemaServer(tmp_path):
+    import girder.utility.config  # noqa
+
+    import wsi_deid.config  # noqa
+    sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'devops', 'wsi_deid'))
+    config = girder.utility.config.getConfig()
+    config[wsi_deid.config.CONFIG_SECTION] = {
+        'import_text_association_columns': [
+            'SurgPathNum',
+            'First_Name',
+            'Last_Name',
+            'Date_of_Birth_mmddyyyy'
+        ]
+    }
+    import provision  # noqa
+    provision.provision()
+    del sys.path[-1]
+
+    importPath = tmp_path / 'import'
+    os.makedirs(importPath, exist_ok=True)
+    exportPath = tmp_path / 'export'
+    os.makedirs(exportPath, exist_ok=True)
+    # unfiledPath = tmp_path / 'unfiled'
+    # os.makedirs(unfiledPath, exist_ok=True)
+    Setting().set(PluginSettings.WSI_DEID_IMPORT_PATH, str(importPath))
+    Setting().set(PluginSettings.WSI_DEID_EXPORT_PATH, str(exportPath))
+    # Setting().set(PluginSettings.WSI_DEID_UNFILED_FOLDER, str(unfiledPath))
+    for filename in {
+        'SEER_Mouse_1_17158539.svs',
+        'SEER_Mouse_1_17158540.svs',
+        'SEER_Mouse_1_17158541.svs',
+        'SEER_Mouse_1_17158542.svs',
+        'SEER_Mouse_1_17158543.svs'
+    }:
+        path = lowres_datastore.fetch(filename)
+        shutil.copy(path, str(importPath / filename))
+    dataPath = os.path.join(os.path.dirname(__file__), 'data')
+    for filename in {'default_schema_deidUpload.csv'}:
+        path = os.path.join(dataPath, filename)
+        shutil.copy(path, importPath / filename)
+    return importPath, exportPath

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -7,7 +7,7 @@ from girder.models.setting import Setting
 
 from wsi_deid.constants import PluginSettings
 
-from .datastore import datastore, lowres_datastore
+from .datastore import datastore
 
 
 @pytest.fixture
@@ -63,7 +63,6 @@ def resetConfig():
     config[wsi_deid.config.CONFIG_SECTION] = {}
 
 
-@pytest.fixture
 def _provisionDefaultSchemaServer(tmp_path):
     import girder.utility.config  # noqa
 
@@ -98,7 +97,7 @@ def _provisionDefaultSchemaServer(tmp_path):
         'SEER_Mouse_1_17158542.svs',
         'SEER_Mouse_1_17158543.svs'
     }:
-        path = lowres_datastore.fetch(filename)
+        path = datastore.fetch(filename)
         shutil.copy(path, str(importPath / filename))
     dataPath = os.path.join(os.path.dirname(__file__), 'data')
     for filename in {'default_schema_deidUpload.csv'}:

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
   coverage
   pooch
   pytest
+  pytest-mock
   pytest-cov
   pytest-girder
   pytest-xdist

--- a/wsi_deid/web_client/tests/wsi_deidDefaultSchemaSpec.js
+++ b/wsi_deid/web_client/tests/wsi_deidDefaultSchemaSpec.js
@@ -1,0 +1,105 @@
+/* globals girderTest, describe, it, expect, waitsFor, runs, $ */
+
+girderTest.importPlugin('homepage', 'jobs', 'large_image', 'large_image_annotation', 'slicer_cli_web', 'histomicsui', 'wsi_deid')
+
+girderTest.startApp();
+
+var tokenId = '0590XY112001';
+
+describe('Mock WebGL', function () {
+    it('mock Webgl', function () {
+        var girder = window.girder;
+        var GeojsViewer = girder.plugins.large_image.views.imageViewerWidget.geojs;
+        girder.utilities.PluginUtils.wrap(GeojsViewer, 'initialize', function (initialize) {
+            this.once('g:beforeFirstRender', function () {
+                window.geo.util.restoreWebglRenderer();
+                window.geo.util.mockWebglRenderer();
+            });
+            initialize.apply(this, arguments);
+        });
+    });
+});
+
+describe('Test WSI DeID plugin with default schema', function () {
+    describe('import', function () {
+        it('logs in as admin', function () {
+            girderTest.login('admin', 'Admin', 'Admin', 'password')();
+            waitsFor(function() {
+                return $('a.g-nav-link[g-target="admin"]').length > 0;
+            }, 'admin console link to load');
+        });
+        it('goes to the WSI DeID collections page', function () {
+            runs(function () {
+                $('a.g-nav-link[g-target="collections"]').click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('.g-collection-create-button:visible').length > 0;
+            });
+            runs(function() {
+                $('.g-collection-list-entry .g-collection-link').click();
+            });
+            girderTest.waitForLoad();
+        });
+        it('goes to the unfiled folder', function () {
+            runs(function () {
+                expect($('.g-folder-list-link').eq(8).text()).toEqual('Unfiled');
+                $('.g-folder-list-link').eq(8).click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('.wsi_deid-import-button').length;
+            }, 'import button to appear');
+        });
+        it('clicks the import button', function () {
+            runs(function () {
+                $('.wsi_deid-import-button').click();
+            });
+            waitsFor(function () {
+                return $('.g-item-list-entry').length
+            }, 'imported images to load as items');
+            girderTest.waitForLoad();
+        });
+        it('expects 1 to be 1', function () {
+            runs(function () {
+                expect(1).toBe(1);
+            });
+        });
+    });
+    describe('refile one image', function () {
+        it('checks length of items', function () {
+            expect($('.g-item-list-entry').length).toEqual(5);
+        });
+        it('opens the first item', function () {
+            runs(function () {
+                $('.g-item-list-link').eq(0).click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('.g-refile-button').length
+            }, 'refile button to appear');
+        });
+        it('refiles the image', function () {
+            runs(function () {
+                var tokenInput = $('input.g-refile-tokenid').first();
+                tokenInput.val(tokenId);
+            });
+            runs(function () {
+                expect($('input.g-refile-tokenid').first().val()).toEqual(tokenId);
+            });
+            runs(function () {
+                $('.g-refile-button').first().click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('.g-hui-redact').length;
+            });
+            waitsFor(function () {
+                return $('.g-workflow-button[action="process"]').length;
+            }, 'redaction controls to become available');
+            runs(function () {
+                expect($('.g-workflow-button[action="process"]').length).toBe(1);
+            });
+        });
+    });
+});

--- a/wsi_deid/web_client/tests/wsi_deidDefaultSchemaSpec.js
+++ b/wsi_deid/web_client/tests/wsi_deidDefaultSchemaSpec.js
@@ -5,6 +5,7 @@ girderTest.importPlugin('homepage', 'jobs', 'large_image', 'large_image_annotati
 girderTest.startApp();
 
 var tokenId = '0590XY112001';
+var usedTokenIds = [tokenId];
 
 describe('Mock WebGL', function () {
     it('mock Webgl', function () {
@@ -60,11 +61,6 @@ describe('Test WSI DeID plugin with default schema', function () {
             }, 'imported images to load as items');
             girderTest.waitForLoad();
         });
-        it('expects 1 to be 1', function () {
-            runs(function () {
-                expect(1).toBe(1);
-            });
-        });
     });
     describe('refile one image', function () {
         it('checks length of items', function () {
@@ -99,6 +95,89 @@ describe('Test WSI DeID plugin with default schema', function () {
             }, 'redaction controls to become available');
             runs(function () {
                 expect($('.g-workflow-button[action="process"]').length).toBe(1);
+            });
+        });
+    });
+    describe('refile multiple images together under new TokenID', function () {
+        it('goes to the WSI DeID collections page', function () {
+            runs(function () {
+                $('a.g-nav-link[g-target="collections"]').click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('.g-collection-create-button:visible').length > 0;
+            });
+            runs(function() {
+                $('.g-collection-list-entry .g-collection-link').click();
+            });
+            girderTest.waitForLoad();
+        });
+        it('goes to the unfiled folder', function () {
+            runs(function () {
+                expect($('.g-folder-list-link').eq(8).text()).toEqual('Unfiled');
+                $('.g-folder-list-link').eq(8).click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('.wsi_deid-import-button').length;
+            }, 'import button to appear');
+        });
+        it('selects multiple images for refile', function () {
+            runs(function () {
+                var checkboxes = $('input.g-list-checkbox');
+                checkboxes.eq(0).click();
+                checkboxes.eq(1).click();
+                waitsFor(function () {
+                    return $('.g-refile-button').length;
+                }, 'refile button to appear');
+            });
+        });
+        it('refiles the images', function () {
+            runs(function () {
+                $('.g-refile-button').first().click();
+            });
+            girderTest.waitForLoad();
+            runs(function () {
+                expect($('.g-item-list-entry').length).toEqual(2);
+            });
+        });
+        it('goes to the WSI DeID collections page', function () {
+            runs(function () {
+                $('a.g-nav-link[g-target="collections"]').click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('.g-collection-create-button:visible').length > 0;
+            });
+            runs(function() {
+                $('.g-collection-list-entry .g-collection-link').click();
+            });
+            girderTest.waitForLoad();
+        });
+        it('verifies a new folder in AvailableToProcess', function () {
+            runs(function () {
+                expect($('.g-folder-list-link').eq(1).text()).toEqual('AvailableToProcess');
+                $('.g-folder-list-link').eq(1).click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('.wsi_deid-import-button').length;
+            }, 'import button to appear');
+            runs(function () {
+                expect($('.g-folder-list-link').length).toEqual(2);
+            });
+        });
+        it('verifies 2 images in new folder', function () {
+            runs(function () {
+                var newFolder = $('.g-folder-list-link').filter(function () {
+                    return $(this).text() !== tokenId;
+                }).first();
+                usedTokenIds.push(newFolder.text());
+                newFolder.click();
+            });
+            girderTest.waitForLoad();
+            runs(function () {
+                expect($('.g-item-list-entry').length).toEqual(2);
             });
         });
     });


### PR DESCRIPTION
addresses (partially) #295 

When using the default schema, images can be ingested into the `Unfiled` directory. Work in #310 and #260 allowed for manually refiling these images into the `AvailableToProcess` folder. The changes here add tests for importing images using the default schema, refiling one image from the item view, and bulk refiling from the `Unfiled` folder itself.

The test data is on DKC and is comprised of low-res whole slide images.

@manthey I think these are a good start on capturing more workflows in tests, although I think they are far from complete. I think a follow up PR could more carefully test the OCR job (perhaps independently of the import process), but if you think there are any glaring omissions from this initial effort I would not mind adding them to this PR.