### PR TITLE
Improve test isolation.

### DIFF
--- a/tests/test_web_client.py
+++ b/tests/test_web_client.py
@@ -3,14 +3,14 @@ import os
 import pytest
 from pytest_girder.web_client import runWebClientTest
 
-from .utilities import provisionBoundServer  # noqa
+from .utilities import provisionBoundServer, resetConfig  # noqa
 
 
 @pytest.mark.plugin('wsi_deid')
 @pytest.mark.parametrize('spec', (
     'wsi_deidSpec.js',
 ))
-def testWebClient(boundServer, db, spec, provisionBoundServer):  # noqa
+def testWebClient(boundServer, db, spec, provisionBoundServer, resetConfig):  # noqa
     import wsi_deid.import_export
 
     wsi_deid.import_export.SCHEMA_FILE_PATH = os.path.join(

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -40,3 +40,14 @@ def _provisionServer(tmp_path):
         path = os.path.join(dataPath, filename)
         shutil.copy(path, importPath / filename)
     return importPath, exportPath
+
+
+@pytest.fixture
+def resetConfig():
+    import girder.utility.config
+
+    import wsi_deid.config
+
+    # Use default wsi_deid config for tests
+    config = girder.utility.config.getConfig()
+    config[wsi_deid.config.CONFIG_SECTION] = {}

--- a/wsi_deid/import_export.py
+++ b/wsi_deid/import_export.py
@@ -310,7 +310,7 @@ def ingestOneItem(importFolder, imagePath, record, ctx, user, newItems):
     # TODO: (a) use the getTargetAssetstore method from Upload(), (b) ensure
     # that the assetstore is a filesystem assestore.
     assetstore = Assetstore().getCurrent()
-    name = record[imageNameField] + os.path.splitext(record['name'])[1]
+    name = (record[imageNameField] or '') + os.path.splitext(record['name'])[1]
     mimeType = 'image/tiff'
     if Item().findOne({'name': {'$regex': '^%s\\.' % record[imageNameField]}}):
         return 'duplicate'


### PR DESCRIPTION
If you run the tests on a system that has a girder.cfg file installed (e.g., in ~/.girder directory), the tests are affected by the local file.  Adjust the web client test to ignore that and use a black wsi_deid config section for testing.