### PR TITLE
Ignore a new bugbear warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -104,6 +104,8 @@ ignore =
     # W503 - Line break after binary operator
     W504,
     W391,
+    # B028 - Consider replacing f"'{foo}'" with f"{foo!r}" -- requires at least py 3.8
+    B028,
 
 [pytest]
 addopts = --verbose --strict --showlocals --cov-report=term --cov-report=xml --cov


### PR DESCRIPTION
This warning doesn't apply to some versions of python we still work with.