### PR TITLE
Matching API

### DIFF
--- a/wsi_deid/__init__.py
+++ b/wsi_deid/__init__.py
@@ -48,6 +48,8 @@ def validateSettingsFolder(doc):
     PluginSettings.WSI_DEID_REMOTE_USER,
     PluginSettings.WSI_DEID_REMOTE_PASSWORD,
     PluginSettings.WSI_DEID_OCR_ON_IMPORT,
+    PluginSettings.WSI_DEID_DB_API_URL,
+    PluginSettings.WSI_DEID_DB_API_KEY,
 })
 def validateSettingsImportExport(doc):
     if not doc.get('value', None):

--- a/wsi_deid/constants.py
+++ b/wsi_deid/constants.py
@@ -22,6 +22,8 @@ class PluginSettings(object):
     WSI_DEID_OCR_ON_IMPORT = 'wsi_deid.ocr_on_import'
     WSI_DEID_UNFILED_FOLDER = 'wsi_deid.unfiled_folder'
     WSI_DEID_SCHEMA_FOLDER = 'wsi_deid.schema_folder'
+    WSI_DEID_DB_API_URL = 'wsi_deid.db_api_url'
+    WSI_DEID_DB_API_KEY = 'wsi_deid.db_api_key'
 
 
 class SftpMode(Enum):

--- a/wsi_deid/matching_api.py
+++ b/wsi_deid/matching_api.py
@@ -1,0 +1,153 @@
+import itertools
+import json
+import re
+
+import requests
+
+
+class APISearch:
+    dateDOBRE = re.compile(
+        r'^(?P<dob>(?:DOB(?:[:.]|)|))'
+        r'(?P<month>[0-1]?\d)(?:[-_/.])(?P<day>[0-3]?\d)(?:[-_/.])(?P<year>(?:19|20|)\d\d)$')
+    dateDOB2RE = re.compile(
+        r'^(?P<dob>(?:DOB(?:[:.]|)|))'
+        r'(?P<year>(?:19|20)\d\d)(?:[-_/.])(?P<month>[0-1]?\d)(?:[-_/.])(?P<day>[0-3]?\d)$')
+    dateRE = re.compile(
+        r'(?P<month>\d?\d)(?:[-_/.])(?P<day>\d?\d)(?:[-_/.])(?P<year>(?:19|20|)\d\d)$')
+    date2RE = re.compile(
+        r'(?P<year>(?:19|20|)\d\d)(?:[-_/.])(?P<month>\d?\d)(?:[-_/.])(?P<day>\d?\d)$')
+    nameRE = re.compile(r'^(?P<name>[a-zA-Z]{2,50})$')
+    name1RE = re.compile(r'^(?P<name>[a-zA-Z][a-z]{1,49})(?:[A-Z][a-zA-Z]{1,49})$')
+    name2RE = re.compile(r'^(?:[a-zA-Z][a-z]{1,49})(?P<name>[A-Z][a-z][a-zA-Z]{0,48})$')
+    name3RE = re.compile(r'^(?P<name>[a-zA-Z]{2,50})(?:[-_/.])(?:[a-zA-Z]{2,50})$')
+    name4RE = re.compile(r'^(?:[a-zA-Z]{2,50})(?:[-_/.])(?P<name>[a-zA-Z]{2,50})$')
+    pathnumRE = re.compile(r'^(?P<pathnum>(?:\w{2,10}|\d{2,10})[-_/.](?:\w{2,10}|\d{2,10}))$')
+    matchers = {
+        'date_of_birth': {
+            're': [dateDOBRE, dateDOB2RE],
+            'format': lambda match: '%02d-%02d-%04d' % (
+                int(match['month']),
+                int(match['day']),
+                int(match['year']) if int(match['year']) > 100 else (int(match['year']) + 2000),
+            ),
+        },
+        'date_of_service': {
+            're': [dateRE, date2RE],
+            'format': lambda match: '%02d-%02d-%04d' % (
+                int(match['month']),
+                int(match['day']),
+                int(match['year']) if int(match['year']) > 100 else (int(match['year']) + 2000),
+            ),
+        },
+        'name_first': {
+            're': [nameRE, name1RE, name2RE, name3RE, name4RE],
+            'format': lambda match: match['name'],
+            'skip': ['Hosp', 'dsoH', 'ctr', 'mc', 'jw'],
+        },
+        'name_last': {
+            're': [nameRE, name1RE, name2RE, name3RE, name4RE],
+            'format': lambda match: match['name'],
+            'skip': ['Hosp', 'dsoH', 'ctr', 'mc', 'jw'],
+        },
+        'path_case_num': {
+            're': [pathnumRE],
+            'format': lambda match: match['pathnum'].replace('_', '-').replace(
+                '.', '-').replace('/', '-'),
+        },
+    }
+
+    confidenceThreshold = 0.75
+
+    def __init__(self, url=None, apikey=None, logger=None):
+        """
+        Initialize the class with the api url and key.
+        """
+        if logger is None:
+            try:
+                from girder import logger
+            except Exception:
+                import logging
+
+                logger = logging.getLogger('matching_api')
+                logger.setLevel(logging.DEBUG)
+                logger.addHandler(logging.StreamHandler())
+        self.logger = logger
+        if url is None or apikey is None:
+            try:
+                from girder.models.setting import Setting
+
+                from .constants import PluginSettings
+
+                if not apikey and not url:
+                    apikey = Setting().get(PluginSettings.WSI_DEID_DB_API_KEY)
+                url = url or Setting().get(PluginSettings.WSI_DEID_DB_API_URL)
+            except Exception:
+                self.logger.exception('Failed to get API url and key')
+        self.url = url
+        self.apikey = apikey
+
+    def addMatches(self, matches, matchkey, word):
+        matches.setdefault(matchkey, [])
+        matcherlist = self.matchers[matchkey]
+        for matcher in matcherlist['re']:
+            groups = matcher.match(word)
+            if groups:
+                value = matcherlist['format'](groups.groupdict())
+                if value.lower() in [v.lower() for v in matcherlist.get('skip', [])]:
+                    continue
+                matches[matchkey].append({
+                    'word': word,
+                    'value': value})
+
+    def getQueryList(self, ocrRecord):
+        # Sort the works by confidence and count, culling for confidence
+        words = {e[-2]: e[-1] for e in sorted([
+            (-v['average_confidence'], -v['count'], k, v)
+            for k, v in ocrRecord.items()
+            if v['average_confidence'] >= self.confidenceThreshold])}
+        matches = {key: [] for key in self.matchers}
+        for word in words:
+            for key in self.matchers:
+                self.addMatches(matches, key, word)
+        for matchlist in matches.values():
+            matchlist.append(None)
+        queries = []
+        for values in itertools.product(*matches.values()):
+            params = {}
+            used = set()
+            for k, v in zip(matches.keys(), values):
+                if v is not None and (v['word'], v['value']) not in used:
+                    params[k] = v['value']
+                    used.add((v['word'], v['value']))
+            if (len(params) >= 3 and (
+                    params.get('name_first') or params.get('name_last')) and (
+                    params.get('date_of_birth') or params.get('path_case_num'))):
+                queries.append((-len(params), len(queries), params))
+        queries = [entry[-1] for entry in sorted(queries)]
+        return queries
+
+    def lookupQuery(self, query):
+        self.logger.info('Checking matching API for %r from %s', query, self.url)
+        if not self.url or not self.apikey:
+            return []
+        headers = {
+            'X-SEERDMS-API-Key': self.apikey,
+            'Content-Type': 'application/json',
+        }
+        try:
+            req = requests.post(self.url, headers=headers, data=json.dumps(query))
+        except Exception:
+            self.logger.exception('Failed to query API')
+        return req.json()
+
+    def lookupQueries(self, queryList):
+        for query in queryList:
+            result = self.lookupQuery(query)
+            if len(result):
+                self.logger.info('Found match from API for %r', query)
+                return result
+        return []
+
+    def lookupOcrRecord(self, ocrRecord):
+        queryList = self.getQueryList(ocrRecord)
+        return self.lookupQueries(queryList)

--- a/wsi_deid/web_client/package.json
+++ b/wsi_deid/web_client/package.json
@@ -17,7 +17,7 @@
         ]
     },
     "scripts": {
-        "lint": "eslint . && pug-lint . && stylint",
+        "lint": "eslint . && pug-lint . && stylus-supremacy format --compare ./**/*.styl --options package.json",
         "format": "eslint --cache --fix . && stylus-supremacy format ./**/*.styl --replace --options package.json"
     },
     "dependencies": {

--- a/wsi_deid/web_client/stylesheets/MatchingDialog.styl
+++ b/wsi_deid/web_client/stylesheets/MatchingDialog.styl
@@ -1,0 +1,20 @@
+.modal-dialog.matching-dialog
+  label
+    min-width 175px
+
+  input.form-control
+    display inline-block
+    width 275px
+
+  .form-group
+    margin-bottom 7px
+
+    button
+      margin-left 15px
+
+  #lookup-results
+    th:first-child, td:first-child
+      padding-left 0
+
+    th, td
+      padding-left 10px

--- a/wsi_deid/web_client/templates/ConfigView.pug
+++ b/wsi_deid/web_client/templates/ConfigView.pug
@@ -169,6 +169,22 @@ form#g-wsi_deid-form(role="form")
     p.g-hui-description
       | Run a background job to find label text on new images during an import
     input#g-wsi-deid-ocr-on-import.input-sm(type="checkbox", checked=(settings['wsi_deid.ocr_on_import'] ? "checked" : undefined))
+  .form-group
+    label(for="g-wsi-deid-db-api-url") SEER*DMS URL
+    p.g-hui-description
+      | Remote address to match additional pathology case information.
+    input#g-wsi-deid-db-api-url.form-control.input-sm(
+        type="text", value=settings['wsi_deid.db_api_url'] || '',
+        title="The SEER*DMS url to check for case information.  This might be something like https://demo.seerdms.com/api/matching/wsi",
+        spellcheck="false")
+  .form-group
+    label(for="g-wsi-deid-db-api-key") SEER*DMS API Key
+    p.g-hui-description
+      | The authorized API key used to validate requests to the matching service.
+    input#g-wsi-deid-db-api-key.form-control.input-sm(
+        type="text", value=settings['wsi_deid.db_api_key'] || '',
+        title="The SEER*DMS API key",
+        spellcheck="false")
   p#g-hui-error-message.g-validation-failed-message
 .g-hui-buttons
   button#g-hui-save.btn.btn-sm.btn-primary Save

--- a/wsi_deid/web_client/templates/ItemView.pug
+++ b/wsi_deid/web_client/templates/ItemView.pug
@@ -1,12 +1,12 @@
 -
   var folderButtonList = {
-    ingest: ['process', 'quarantine', 'ocr', 'reject'],
+    ingest: ['process', 'quarantine', 'ocr', 'matching', 'reject'],
     quarantine: ['process', 'unquarantine', 'reject'],
     processed: ['quarantine', 'finish'],
     rejected: ['quarantine'],
     original: ['quarantine'],
     finished: ['quarantine'],
-    unfiled: []
+    unfiled: ['matching']
   };
   var buttons = {
     process: {name: 'Redact Image', title: 'Keep a copy of the original image, redact marked fields, and move the result to the redacted folder', color: 'success'},
@@ -15,9 +15,13 @@
     unquarantine: {name: 'Undo Quarantine', title: 'Move this image back to its previous location before it was quarantined', color: 'default'},
     finish: {name: 'Approve', title: 'Move this image to the approved folder', color: 'primary'},
     ocr: {name: 'Find Label Text', title: 'Perform OCR on this image', color: 'default'},
+    matching: {name: 'Database Lookup', title: 'Lookup records from a configured database', color: 'default', class: 'g-matching-button'},
     refile: {name: 'Refile Image', title: 'Pick or assign a name to the image and move it to be processed.', color: 'success'}
   };
   var buttonList = folderButtonList[project_folder] || ['quarantine']
+  if (!hasMatchingApi) {
+    buttonList = buttonList.filter((val) => val !== 'matching');
+  }
 
 .g-widget-metadata-header.workflow
   i.icon-right-circled
@@ -37,7 +41,7 @@
       button.g-refile-button.btn(class='btn-'+buttons.refile.color, action=button, title=buttons.refile.title) #{buttons.refile.name}
   for button in buttonList
     - var isDisabled = button === 'reject' && require_reject_reason
-    button.g-workflow-button.btn(class='btn-'+buttons[button].color, action=button, title=buttons[button].title, disabled=isDisabled) #{buttons[button].name}
+    button.btn(class='btn-'+buttons[button].color + ' ' + (buttons[button].class || 'g-workflow-button'), action=button, title=buttons[button].title, disabled=isDisabled) #{buttons[button].name}
   if buttonList.includes('reject') && rejection_reasons.length > 0 && require_reject_reason
     select.wsi-deid-reject-reason.form-control.input-sm(title="Select a reason for rejecting this image")
       option(value="none", selected=true) Keep (do not reject)

--- a/wsi_deid/web_client/templates/MatchingDialog.pug
+++ b/wsi_deid/web_client/templates/MatchingDialog.pug
@@ -1,0 +1,67 @@
+.modal-dialog.matching-dialog(role='document')
+  .modal-content
+    form.modal-form(role='form')
+      .modal-header
+        button.close(type='button', data-dismiss='modal', aria-label='Close')
+          span(aria-hidden='true') &times;
+        h3.modal-title Database Lookup
+      .modal-body
+        .form-group
+          img(src=label_image_url)
+        .form-group
+          label(for='wsi-deid-matching-path_case_num') Pathology Case Number
+          input#wsi-deid-matching-path_case_num.matching-value.input-sm.form-control(
+            key='path_case_num', type='text', placeholder='Enter a pathology case number for matching')
+        .form-group
+          label(for='wsi-deid-matching-name_last') Last Name
+          input#wsi-deid-matching-name_last.matching-value.input-sm.form-control(
+            key='name_last', type='text', placeholder='Enter a last name for matching')
+        .form-group
+          label(for='wsi-deid-matching-name_first') First Name
+          input#wsi-deid-matching-name_first.matching-value.input-sm.form-control(
+            key='name_first', type='text', placeholder='Enter a first name for matching')
+        .form-group
+          label(for='wsi-deid-matching-date_of_service') Date of Service
+          input#wsi-deid-matching-date_of_service.matching-value.input-sm.form-control(
+            key='date_of_service', type='text', placeholder='Enter a date of service for matching')
+        .form-group
+          label(for='wsi-deid-matching-date_of_birth') Date of Birth
+          input#wsi-deid-matching-date_of_birth.matching-value.input-sm.form-control(
+            key='date_of_birth', type='text', placeholder='Enter a date of birth for matching')
+          button.btn.btn-primary.h-lookup(type='button') Lookup
+        h4.modal-title Results
+        table#lookup-results.hidden
+          tr
+            th Token ID
+            th Tumors
+            th
+          tr.hidden(record="none")
+            td.token-id-label none
+            td.result-entry
+          tr.hidden(record="0")
+            td.token-id-label
+            td.result-entry
+            td.apply
+              button.btn.btn-primary.h-apply(type='button') Apply
+          tr.hidden(record="1")
+            td.token-id-label
+            td.result-entry
+            td.apply
+              button.btn.btn-primary.h-apply(type='button') Apply
+          tr.hidden(record="2")
+            td.token-id-label
+            td.result-entry
+            td.apply
+              button.btn.btn-primary.h-apply(type='button') Apply
+          tr.hidden(record="3")
+            td.token-id-label
+            td.result-entry
+            td.apply
+              button.btn.btn-primary.h-apply(type='button') Apply
+          tr.hidden(record="4")
+            td.token-id-label
+            td.result-entry
+            td.apply
+              button.btn.btn-primary.h-apply(type='button') Apply
+      .modal-footer
+        button.btn.btn-default.h-cancel(type='button', data-dismiss='modal') Cancel

--- a/wsi_deid/web_client/views/ConfigView.js
+++ b/wsi_deid/web_client/views/ConfigView.js
@@ -61,7 +61,9 @@ var ConfigView = View.extend({
             'wsi_deid.sftp_mode': { name: 'SFTP Mode', id: 'g-wsi-deid-sftp-mode' },
             'wsi_deid.ocr_on_import': { name: 'Find Label Text on Import', id: 'g-wsi-deid-ocr-on-import' },
             'wsi_deid.unfiled_folder': { name: 'Unfiled', id: 'g-wsi-deid-unfiled-folder' },
-            'wsi_deid.schema_folder': { name: 'Schema', id: 'g-wsi-deid-schema-folder' }
+            'wsi_deid.schema_folder': { name: 'Schema', id: 'g-wsi-deid-schema-folder' },
+            'wsi_deid.db_api_url': { name: 'SEER*DMS Matching URL', id: 'g-wsi-deid-db-api-url' },
+            'wsi_deid.db_api_key': { name: 'SEER*DMS API Key', id: 'g-wsi-deid-db-api-key' }
         };
         this._browserWidgetView = {};
         $.when(

--- a/wsi_deid/web_client/views/ItemView.js
+++ b/wsi_deid/web_client/views/ItemView.js
@@ -12,6 +12,7 @@ import ItemViewWidget from '@girder/large_image/views/itemViewWidget';
 import ItemViewTemplate from '../templates/ItemView.pug';
 import ItemViewNextTemplate from '../templates/ItemViewNext.pug';
 import ItemViewRedactAreaTemplate from '../templates/ItemViewRedactArea.pug';
+import MatchingDialog from './MatchingDialog';
 import '../stylesheets/ItemView.styl';
 import {
     formats, getRedactList, putRedactList, goToNextUnprocessedItem,
@@ -433,6 +434,10 @@ wrap(ItemView, 'render', function (render) {
         });
     };
 
+    const matchingButton = (event) => {
+        MatchingDialog({ model: this.model, itemView: this });
+    };
+
     const rejectionReasonChanged = (event, settings) => {
         const newValue = event.target.value;
         const otherSelect = this.$el.find('.wsi-deid-reject-reason').not(event.target).first();
@@ -632,7 +637,8 @@ wrap(ItemView, 'render', function (render) {
         $('#g-app-body-container').children(':not(.g-widget-next-container)').last().after(ItemViewTemplate({
             project_folder: folderType,
             require_reject_reason: settings.require_reject_reason || false,
-            rejection_reasons: rejectionReasons
+            rejection_reasons: rejectionReasons,
+            hasMatchingApi: settings['wsi_deid.db_api_url']
         }));
         if (folderType === 'unfiled') {
             restRequest({
@@ -657,6 +663,7 @@ wrap(ItemView, 'render', function (render) {
         }
         this.events['click .g-workflow-button'] = workflowButton;
         this.events['click .g-refile-button'] = refileButton;
+        this.events['click .g-matching-button'] = matchingButton;
         this.events['change .wsi-deid-reject-reason'] = (event) => rejectionReasonChanged(event, settings);
         /* Place an area redaction control in the item header */
         if (hasRedactionControls && getFormat() !== 'isyntax') {

--- a/wsi_deid/web_client/views/MatchingDialog.js
+++ b/wsi_deid/web_client/views/MatchingDialog.js
@@ -1,0 +1,120 @@
+import $ from 'jquery';
+import events from '@girder/core/events';
+import { getApiRoot, restRequest } from '@girder/core/rest';
+import View from '@girder/core/views/View';
+
+import '@girder/core/utilities/jquery/girderModal';
+import matchingDialog from '../templates/MatchingDialog.pug';
+import '../stylesheets/MatchingDialog.styl';
+
+
+const MatchingDialog = View.extend({
+    events: {
+        'click .h-lookup': '_lookup',
+        'click .h-apply': '_apply'
+    },
+
+    initialize(settings) {
+        this.model = settings.model;
+        this.itemView = settings.itemView;
+    },
+
+    render() {
+        this.$el.html(
+            matchingDialog({
+                label_image_url: `${getApiRoot()}/item/${this.model.id}/tiles/images/label?width=400&height=400&_${this.model.get('updated')}`
+            })
+        ).girderModal(this);
+        return this;
+    },
+
+    _lookup(evt) {
+        const params = {};
+        this.$el.find('.matching-value').each(function () {
+            const val = ($(this).val() || '').trim();
+            const key = $(this).attr('key');
+            if (val) {
+                params[key] = val;
+            }
+        });
+        this.$el.find('tr[record]').addClass('hidden');
+        this.$el.find('#lookup-results').addClass('hidden');
+        restRequest({
+            method: 'POST',
+            url: `wsi_deid/matching`,
+            contentType: 'application/json',
+            data: JSON.stringify(params),
+            error: null
+        }).done((resp) => {
+            this.last_results = resp;
+            if (!resp.length) {
+                this.$el.find('tr[record="none"]').removeClass('hidden');
+            } else {
+                for (let idx = 0; idx < 5 && idx < resp.length; idx += 1) {
+                    const results = [];
+                    resp[idx].tumors.forEach((t) => {
+                        Object.entries(t).forEach(([k, v]) => {
+                            results.push($('<div>').text(`${k}: ${v}`));
+                        });
+                    });
+                    this.$el.find(`tr[record="${idx}"] td.token-id-label`).text(resp[idx].token_id);
+                    this.$el.find(`tr[record="${idx}"] td.result-entry`).empty();
+                    results.forEach((d) => {
+                        this.$el.find(`tr[record="${idx}"] td.result-entry`).append(d);
+                    });
+                    this.$el.find(`tr[record="${idx}"]`).removeClass('hidden');
+                }
+            }
+            this.$el.find('#lookup-results').removeClass('hidden');
+        });
+    },
+
+    _apply(evt) {
+        evt.preventDefault();
+        const record = this.last_results[+($(evt.target).closest('tr[record]').attr('record'))];
+        restRequest({
+            method: 'POST',
+            url: `wsi_deid/item/${this.model.id}/action/refile/${record.token_id}`,
+            contentType: 'application/json',
+            data: JSON.stringify(record.tumors[0] || {}),
+            error: null
+        }).done((resp) => {
+            const alertMessage = 'Item refiled.';
+            $('.g-hui-loading-overlay').remove();
+            events.trigger('g:alert', {
+                icon: 'ok',
+                text: alertMessage,
+                type: 'success',
+                timeout: 4000
+            });
+            delete this.itemView.model.parent;
+            this.itemView.model.fetch({ success: () => this.render() });
+        }).fail((resp) => {
+            $('.g-hui-loading-overlay').remove();
+            let text = 'Failed to refile item.';
+            if (resp.responseJSON && resp.responseJSON.message) {
+                text += ' ' + resp.responseJSON.message;
+            }
+            events.trigger('g:alert', {
+                icon: 'cancel',
+                text: text,
+                type: 'danger',
+                timeout: 5000
+            });
+        });
+        this.$el.modal('hide');
+    }
+});
+
+
+function show(settings) {
+    const dialog = new MatchingDialog({
+        parentView: null,
+        model: settings.model,
+        itemView: settings.itemView,
+        el: $('#g-dialog-container')
+    });
+    return dialog.render();
+}
+
+export default show;


### PR DESCRIPTION
Add settings for API URL matching.  Add a testing endpoint to simulate results.  Add a matching endpoint to call the API.  When a file is ingested and unfiled, apply the matching queries to file it.

For both unfiled files and available to process files, offer to look up values from the API and refile the file.  If a database API is configured, there is a new button "Lookup" which opens a dialog showing the label image (if any) and having text entry boxes for the lookup fields.  Clicking "Lookup" will print matches.  Selecting "Apply" next to a match will refile the image using that match.