### PR TITLE
Update CUSTOMIZING docs with examples and links

### DIFF
--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -183,3 +183,19 @@ Original Pilot Settings
 -----------------------
 
 To have the same settings as the original pilot, use the ``docker-compose.pilot.yml`` file instead of ``docker-compose.yml``.
+
+..
+  Example Configuration
+  ---------------------
+..
+  Example docker-compose
+  ++++++++++++++++++++++
+..
+  .. include:: ../devops/wsi_deid/docker-compose.example.local.yml
+    :literal:
+..
+  Example girder configuration
+  ++++++++++++++++++++++++++++
+..
+  .. include:: ../devops/wsi_deid/girder.local.conf
+    :literal:

--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -247,16 +247,22 @@ By default, if an image has been imported before, it will not be reimported no m
 Customizing Import and Export Reports
 +++++++++++++++++++++++++++++++++++++
 
-If you modify your import schema, or would otherwise like to change which import data is included in import and export reports, you can specify which upload metadata fields to include in these reports by modifying the ``upload_metadata_for_export_report`` list in ``girder.local.conf``. Setting this value to ``None`` will include all columns except ``InputFileName`` in the export reports.
+If you modify your import schema, or would otherwise like to change which import data is included in import and export reports, you can specify which upload metadata fields to include in these reports by modifying the ``upload_metadata_for_export_report`` list in ``girder.local.conf``.
 
 .. code-block:: python
 
   [wsi_deid]
   ...
-  # Only columns from the import manifest file with these explicit titles will be
-  # added to the custom metadata in exported images.  Set to None to allow all
-  # columns except InputFileName to be added.
-  upload_metadata_add_to_images = None
+  upload_metadata_for_export_report = ["TokenID", "SurgPathNum", "Registry", "Tumor_Rec_Number", "Histology_Code", "Behavior_Code"]
+  ...
+
+Setting this value to ``None`` will include all columns except ``InputFileName`` in the export reports.
+
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  upload_metadata_for_export_report = None
   ...
 
 
@@ -321,6 +327,15 @@ By default, any metadata from the upload excel/csv file except ``InputFileName``
   [wsi_deid]
   ...
   upload_metadata_add_to_images = ["Proc_Seq", "Proc_Type", "Spec_Site"]
+  ...
+
+If the setting is absent or set to ``None``, then all metadata from the upload file, except ``InputFileName``, will be included.
+
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  upload_metadata_add_to_images = None
   ...
 
 

--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -134,6 +134,7 @@ Note that fields specified in ``no_redact_control_keys`` will have redaction dis
   no_redact_control_keys_format_hamamatsu = {
       "^internal;openslide;hamamatsu\.SourceLens$": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$"}
   no_redact_control_keys_format_philips = {}
+  no_redact_control_keys_format_isyntax = {}
   ...
 
 Hiding Metadata Fields
@@ -160,6 +161,20 @@ If these metadata items contain unexpected values (e.g., text where a number was
   hide_metadata_keys_format_hamamatsu = {
       "^internal;openslide;hamamatsu\.((AHEX|MHLN|YRNP|zCoarse|zFine)\[|(X|Y)OffsetFromSlideCentre|ccd.(width|height)|(focalplane|slant)\.(left|right)(top|bottom)|stage.center)": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$"}
   hide_metadata_keys_format_philips = {}
+  hide_metadata_keys_format_isyntax = {}
+  ...
+
+To show ALL possible metadata, set each of these values to ``{}``.
+
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  hide_metadata_keys = {}
+  hide_metadata_keys_format_aperio = {}
+  hide_metadata_keys_format_hamamatsu = {}
+  hide_metadata_keys_format_philips = {}
+  hide_metadata_keys_format_isyntax = {}
   ...
 
 Editing Metadata Values

--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -31,6 +31,8 @@ By default, when metadata or images are redacted, the user must pick the type of
 
 Redaction categories can be configured by changing the ``phi_pii_types`` settings.
 
+`See example configuration <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/devops/wsi_deid/girder.local.conf#L93>`_
+
 Reasons for Rejection
 +++++++++++++++++++++
 

--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -17,6 +17,13 @@ Redacting the top/left of the macro image
 
 When the ``redact_macro_square`` setting is set to ``True``, the upper left square of all macro images will automatically be blacked out.  This region often contains the label on the slide, and sometimes that can contain PHI that is visible with contrast or other image adjustment.
 
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  redact_macro_square = True
+  ...
+
 Redaction Categories
 ++++++++++++++++++++
 

--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -31,22 +31,77 @@ By default, when metadata or images are redacted, the user must pick the type of
 
 Redaction categories can be configured by changing the ``phi_pii_types`` settings.
 
-`See example configuration <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/devops/wsi_deid/girder.local.conf#L93>`_
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  require_redact_category = True
+  phi_pii_types = [{
+      "category": "Personal_Info",
+      "text": "Personal Information",
+      "types": [
+          { "key": "Patient_Name", "text": "Patient Name" },
+          { "key": "Patient_DOB", "text": "Date of Birth " },
+          { "key": "SSN", "text": "Social Security Number" },
+          { "key": "Other_Personal", "text": "Other Personal" }]}, {
+      "category": "Demographics",
+      "key": "Demographics",
+      "text": "Demographics"}, {
+      "category": "Facility_Physician",
+      "key": "Facility_Physician",
+      "text": "Facility/Physician Information"}, {
+      "category": "Other_PHIPII",
+      "key": "Other_PHIPII",
+      "text": "Other PHI/PII"}]
+  ...
 
 Reasons for Rejection
 +++++++++++++++++++++
 
 Rejecting images can be configured to require a reason for rejection. This is controlled by the setting ``require_reject_reason``. Reasons for rejection can be configured via the ``reject_reasons`` setting.
 
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  require_reject_reason = True
+  reject_reasons = [{
+      "category": "Cannot_Redact",
+      "text": 'Cannot redact PHI',
+      "key": 'Cannot_Redact' }, {
+      "category": 'Slide_Quality',
+      "text": 'Slide Quality',
+      "types": [
+          { "key": "Chatter_Tears", "text": "Chatter/tears in tissue" },
+          { "key": "Folded_Tissue", "text": "Folded tissue" },
+          { "key": "Overstaining", "text": "Overstaining" },
+          { "key": "Cover_Slip", "text": "Cover slip issues" },
+          { "key": "Debris", "text": "Debris or dust" },
+          { "key": "Air_Bubbles", "text": "Air bubbles" },
+          { "key": "Pathologist_Markings", "text": "Pathologist's Markings" },
+          { "key": "Other_Slide_Quality", "text": "Other" }]}, {
+      "category": "Image_Quality",
+      "text": "Image Quality",
+      "types": [
+          { "key": "Out_Of_Focus", "text": "Out of focus" },
+          { "key": "Low_Resolution", "text": "Low resolution" },
+          { "key": "Other_Image_Quality", "text": "Other" }]}]
+  ...
+
 Redacting the Label Image
 +++++++++++++++++++++++++
 
 The label image can be redacted by default if the ``always_redact_label`` value is set to ``True``.  If the label image is redacted, it is replaced with a black square with the output filename printed in it.  The label image is not redacted, the output filename is added to the top of the image.
 
-Label Image Title
-+++++++++++++++++
+Adding the filename as the title of the label image is optional.  If the ``add_title_to_label`` is set to ``False``, it will not be added.  If no title is added and the label image is redacted, the image is removed.
 
-Adding the filename as the title of the label image is option.  If the ``add_title_to_label`` is set to ``False``, it will not be added.  If no title is added and the label image is redacted, the image is removed.
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  always_redact_label = True
+  add_title_to_label = True
+  ...
 
 Disabling the Redaction Control
 +++++++++++++++++++++++++++++++
@@ -62,6 +117,22 @@ In order to disable redaction controls for certain metadata fields, you can add 
 
 Note that fields specified in ``no_redact_control_keys`` will have redaction disabled on all image formats. If you wish to disable redaction of a metadata field on, for example, Aperio images only, you can add that metadata key and expected value to the ``no_redact_control_keys_format_aperio`` dictionary.
 
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  no_redact_control_keys = {
+      "^internal;aperio_version$": "",
+      "^internal;openslide;openslide\.(?!comment$)": "",
+      "^internal;openslide;tiff\.(ResolutionUnit|XResolution|YResolution)$": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$",
+      "^internal;openslide;tiff\.ResolutionUnit": ""}
+  no_redact_control_keys_format_aperio = {
+      "^internal;openslide;aperio\.(AppMag|MPP|Exposure (Time|Scale))$": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$"}
+  no_redact_control_keys_format_hamamatsu = {
+      "^internal;openslide;hamamatsu\.SourceLens$": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$"}
+  no_redact_control_keys_format_philips = {}
+  ...
+
 Hiding Metadata Fields
 ++++++++++++++++++++++
 
@@ -74,10 +145,31 @@ Similar to configuration for disabling redaction, if you wish to hide certain me
 
 If these metadata items contain unexpected values (e.g., text where a number was expected), they will be visible and available for redaction.
 
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  hide_metadata_keys = {
+      "^internal;openslide;openslide\.level\[": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$"}
+  hide_metadata_keys_format_aperio = {
+      "^internal;openslide;(openslide\.comment|tiff\.ImageDescription)$": "",
+      "^internal;openslide;aperio\.(Original(Height|Width)|Left|Top|Right|Bottom|LineArea(X|Y)Offset|LineCameraSkew|Focus Offset|StripeWidth|DisplayColor)": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$"}
+  hide_metadata_keys_format_hamamatsu = {
+      "^internal;openslide;hamamatsu\.((AHEX|MHLN|YRNP|zCoarse|zFine)\[|(X|Y)OffsetFromSlideCentre|ccd.(width|height)|(focalplane|slant)\.(left|right)(top|bottom)|stage.center)": "^\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?)(\s*,\s*[+-]?(\d+([.]\d*)?([eE][+-]?\d+)?|[.]\d+([eE][+-]?\d+)?))*\s*$"}
+  hide_metadata_keys_format_philips = {}
+  ...
+
 Editing Metadata Values
 +++++++++++++++++++++++
 
 Normally, when a metadata field is redacted, its value becomes blank. In ``girder.local.conf``, you can set ``edit_metadata`` to ``True`` to enable editing metadata as part of the redaction process. If editing metadata is enabled, users will have the opportunity to set the value of a redacted metadata field to any value.
+
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  edit_metadata = True
+  ...
 
 Bulk Redation and Review of Metadata
 ++++++++++++++++++++++++++++++++++++
@@ -86,30 +178,69 @@ When viewing a folder of images, you can optionally see all of the metadata that
 
 Note that some image redaction options are not available in the folder list redaction page.
 
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  show_metadata_in_lists = True
+  ...
+
+Image Controls
+++++++++++++++
+
 Next Image Control
-++++++++++++++++++
+""""""""""""""""""
 
 By default, a Next Image control is shown on the left menu bar below Collections and Users.  This is optional and can be removed by setting ``show_next_item`` to ``False`` in the configuration.
 
 Next Folder Control
-+++++++++++++++++++
+"""""""""""""""""""
 
 By default, a Next Folder control is shown on the left menu bar below Collections and Users.  This is optional and can be removed by setting ``show_folder_item`` to ``False`` in the configuration.
 
-Import and Export Controls
-++++++++++++++++++++++++++
+Workflow Control Configuration
+""""""""""""""""""""""""""""""
 
 By default, new data can be imported into the ``AvailableToProcess`` folder and exported from the ``Approved`` folder via specific controls.  Imports require that a manifest spreadsheet file is next to the image files in the import directory.  Images can also be moved or imported into the ``AvailableToProcess`` folder using ordinary item controls in Girder.  If the import and export buttons are not going to be used, they can be hidden by setting the ``show_import_button`` and ``show_export_button`` values to False in the configuration.
+
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  show_next_item = True
+  show_next_folder = True
+  show_import_button = True
+  show_export_button = True
+  ...
+
 
 Reimporting Moved Images
 ++++++++++++++++++++++++
 
 By default, if an image has been imported before, it will not be reimported no matter where it is located in the system.  If you are creating folders besides those used in the basic workflow and want to reimport a file that was moved to one of these non-workflow folders, set the ``reimport_if_moved`` configuration value to True.
 
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  reimport_if_moved = True
+  ...
+
 Customizing Import and Export Reports
 +++++++++++++++++++++++++++++++++++++
 
-If you modify your import schema, or would otherwise like to change which import data is included in import and export reports, you can specify which upload metadata fields to include in these reports by modifying the ``upload_metadata_for_export_report`` list in ``girder.local.conf``. By default, this is set to a subset of the fields in the default import schema.
+If you modify your import schema, or would otherwise like to change which import data is included in import and export reports, you can specify which upload metadata fields to include in these reports by modifying the ``upload_metadata_for_export_report`` list in ``girder.local.conf``. Setting this value to ``None`` will include all columns except ``InputFileName`` to be included in the export reports.
+
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  # Only columns from the import manifest file with these explicit titles will be
+  # added to the custom metadata in exported images.  Set to None to allow all
+  # columns except InputFileName to be added.
+  upload_metadata_add_to_images = None
+  ...
+
 
 Primary Folder and Image Fields
 +++++++++++++++++++++++++++++++
@@ -121,6 +252,16 @@ If the ``validate_image_id_field`` setting is set to ``False``, there is no requ
 Instead of using ``TokenID`` and ``ImageID``, these fields can be specified using the ``folder_name_field`` and ``image_name_field`` fields respectively.
 
 The values in the ``image_name_field`` need to be unique, or only the first row with a specified value will be used.
+
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  # Images will be filed into folders based on this column in the import excel file
+  folder_name_field = "TokenID"
+  # Use column "SampleID" from import excel file to name redacted images
+  image_name_field = "SampleID"
+  ...
 
 Import Schema Modification
 --------------------------
@@ -137,16 +278,33 @@ Using a Schema with no ``InputFileName`` Field
 If you would like to use Optical Character Recognition (OCR) to match images in your import directory with rows on your upload excel/csv file, you need to make the following changes to your schema:
 
 * Ensure your schema does not have a field ``InputFileName``, and there is no corresponding column on your upload file
-* Ensure your schema contains a column for target text, and that the column is specified in ``girder.local.conf``. The property to set is ``import_text_association_column``.
+* Ensure your schema contains one or more columns for target text, and that the column is specified in ``girder.local.conf``. The property to set is ``import_text_association_columns``.
 
 The target text column should contain label text of WSIs in the import directory. During the ingest process, all images in your specified import directory will be ingested into the ``Unfiled`` folder in the ``WSI DeID`` collection. Then, those images will be associated with data found on the upload file. Progress can be tracked as a girder job. If no match can be determined, images will remain in the ``Unfiled`` folder. Images with a match will be transferred to the ``AvailableToProcess`` folder.
 
 If ``InputFileName`` is added to the list of export fields in the ``upload_metadata_for_export_report`` settings, then the original file name will be included in the export report.
 
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  # Attempt to match OCR results with data in these columns from the import excel file
+  import_text_association_columns = ["SurgPathNum", "First_Name", "Last_Name", "Date_of_Birth"]
+  ...
+
+
 Choosing Custom Metadata To Add to Exported Images
 ++++++++++++++++++++++++++++++++++++++++++++++++++
 
-By default, any metadata from the upload excel/csv file except ``InputFileName`` is added to the exported files in the ``ImageDescription`` or ``Software`` metadata tags (depending on format) with a prefix of ``CustomField.`` (e.g., ``CustomField.Proc_Type`` will be added with data from a ``Proc_Type`` column in the ypload file).  This can be configured with the ``upload_metadata_add_to_images`` setting in ``girder.local.conf``.  If present and not None, this setting is a list of columns with will be added to the exported file.
+By default, any metadata from the upload excel/csv file except ``InputFileName`` is added to the exported files in the ``ImageDescription`` or ``Software`` metadata tags (depending on format) with a prefix of ``CustomField.`` (e.g., ``CustomField.Proc_Type`` will be added with data from a ``Proc_Type`` column in the upload file).  This can be configured with the ``upload_metadata_add_to_images`` setting in ``girder.local.conf``.  If present and not None, this setting is a list of columns with will be added to the exported file.
+
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  upload_metadata_add_to_images = ["Proc_Seq", "Proc_Type", "Spec_Site"]
+  ...
+
 
 Creating New TokenIDs for Refiling Images
 +++++++++++++++++++++++++++++++++++++++++
@@ -156,6 +314,13 @@ When using the bulk refile controls to move images from the ``Unfiled`` director
 The pattern should be a string comprised of alphanumeric characters, "#", and "@". When generating a new TokenID, instances of "#" will be replaced with a random digit 0-9 and instances of "@" will be replaced with a letter A-Z.
 
 For example, if the specified pattern is ``0123#@@1###``, a randomly generated TokenID might look like ``01238EJ1449``.
+
+.. code-block:: python
+
+  [wsi_deid]
+  ...
+  new_token_pattern = "####@@#####"
+  ...
 
 An Example to Allow All Import Files
 ++++++++++++++++++++++++++++++++++++
@@ -192,19 +357,3 @@ Original Pilot Settings
 -----------------------
 
 To have the same settings as the original pilot, use the ``docker-compose.pilot.yml`` file instead of ``docker-compose.yml``.
-
-..
-  Example Configuration
-  ---------------------
-..
-  Example docker-compose
-  ++++++++++++++++++++++
-..
-  .. include:: ../devops/wsi_deid/docker-compose.example.local.yml
-    :literal:
-..
-  Example girder configuration
-  ++++++++++++++++++++++++++++
-..
-  .. include:: ../devops/wsi_deid/girder.local.conf
-    :literal:

--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -363,4 +363,4 @@ to run the system with the modified schema and configuration.
 Original Pilot Settings
 -----------------------
 
-To have the same settings as the original pilot, use the ``docker-compose.pilot.yml`` file instead of ``docker-compose.yml``.
+To have the same settings as the original pilot, use the `docker-compose.pilot.yml <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/devops/wsi_deid/docker-compose.pilot.yml>`_ file instead of ``docker-compose.yml``.

--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -3,7 +3,10 @@ Customizing WSI DeID
 
 There are several ways to customize the installation of WSI DeID to change its behavior to better match your desired workflow and use case.
 
-See the files ``devops/wsi_deid/docker-compose.example.local.yml`` and ``devops/wsi_deid/girder.local.conf`` for comments about many of these options.  Broadly, the options in ``devops/wsi_deid/docker-compose.example.local.yml`` change the deployment environment, such as directories that are used and available memory.  The options in ``devops/wsi_deid/girder.local.conf`` change the run-time behavior, such as how label and macro images are redacted.
+See the files following files for examples and additional comments about configuration options:
+
+* ``devops/wsi_deid/docker-compose.example.local.yml``: change the deployment environment, such as directories that are used and available memory. `View entire example docker-compose file <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/devops/wsi_deid/docker-compose.example.local.yml>`_.
+* ``devops/wsi_deid/girder.local.conf``: change the run-time behavior, such as how label and macro images are redacted. `View entire example girder config file <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/devops/wsi_deid/girder.local.conf>`_.
 
 When modifying ``devops/wsi_deid/girder.local.conf``, you'll also need to enable using the custom file by uncommenting a few lines as described in ``devops/wsi_deid/docker-compose.example.local.yml``.
 
@@ -229,7 +232,7 @@ By default, if an image has been imported before, it will not be reimported no m
 Customizing Import and Export Reports
 +++++++++++++++++++++++++++++++++++++
 
-If you modify your import schema, or would otherwise like to change which import data is included in import and export reports, you can specify which upload metadata fields to include in these reports by modifying the ``upload_metadata_for_export_report`` list in ``girder.local.conf``. Setting this value to ``None`` will include all columns except ``InputFileName`` to be included in the export reports.
+If you modify your import schema, or would otherwise like to change which import data is included in import and export reports, you can specify which upload metadata fields to include in these reports by modifying the ``upload_metadata_for_export_report`` list in ``girder.local.conf``. Setting this value to ``None`` will include all columns except ``InputFileName`` in the export reports.
 
 .. code-block:: python
 
@@ -352,6 +355,7 @@ will start the system with these permissive import options.  If you modify the s
     docker-compose -f docker-compose.yml -f docker-compose.local.yml restart
 
 to run the system with the modified schema and configuration.
+
 
 Original Pilot Settings
 -----------------------

--- a/docs/CUSTOMIZING.rst
+++ b/docs/CUSTOMIZING.rst
@@ -5,8 +5,8 @@ There are several ways to customize the installation of WSI DeID to change its b
 
 See the files following files for examples and additional comments about configuration options:
 
-* ``devops/wsi_deid/docker-compose.example.local.yml``: change the deployment environment, such as directories that are used and available memory. `View entire example docker-compose file <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/devops/wsi_deid/docker-compose.example.local.yml>`_.
-* ``devops/wsi_deid/girder.local.conf``: change the run-time behavior, such as how label and macro images are redacted. `View entire example girder config file <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/devops/wsi_deid/girder.local.conf>`_.
+* `devops/wsi_deid/docker-compose.example.local.yml <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/devops/wsi_deid/docker-compose.example.local.yml>`_: change the deployment environment, such as directories that are used and available memory.
+* `devops/wsi_deid/girder.local.conf <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/devops/wsi_deid/girder.local.conf>`_: change the run-time behavior, such as how label and macro images are redacted.
 
 When modifying ``devops/wsi_deid/girder.local.conf``, you'll also need to enable using the custom file by uncommenting a few lines as described in ``devops/wsi_deid/docker-compose.example.local.yml``.
 
@@ -269,7 +269,7 @@ The values in the ``image_name_field`` need to be unique, or only the first row 
 Import Schema Modification
 --------------------------
 
-Import excel files can be customized, allowing for additional metadata to be captured during the import process. The expected schema for import files is described in ``wsi_deid/schema/importManifestScheme.json``. An example of a modified schema can be found in ``importManifestSchema.example.json``. In this example schema, the fields  ``Tumor_Rec_Number``, ``Histology_Code``, and ``Behavior_Code`` have been added. Each of these new fields uses a regular expression for validation. Enums (a set of values) can be used for validation instead of pattern matching (see the property ``Proc_Type`` for an example).
+Import excel files can be customized, allowing for additional metadata to be captured during the import process. The expected schema for import files is described in `wsi_deid/schema/importManifestScheme.json <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/wsi_deid/schema/importManifestSchema.json>`_. An example of a modified schema can be found in `importManifestSchema.example.json <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/wsi_deid/schema/importManifestSchema.example.json>`_. In this example schema, the fields  ``Tumor_Rec_Number``, ``Histology_Code``, and ``Behavior_Code`` have been added. Each of these new fields uses a regular expression for validation. Enums (a set of values) can be used for validation instead of pattern matching (see the property ``Proc_Type`` for an example).
 
 Currently, import logic requires ``TokenID``, ``Proc_Seq``, ``Slide_ID``, and ``InputFileName`` in order to properly find and rename images in the import directory. These properties in the schema should not be modified at this time.
 
@@ -330,7 +330,10 @@ An Example to Allow All Import Files
 
 You can use a schema and config file to allow all files to be imported.  If there is an excel file with some minimum standards, files will be added to the ``AvailableToProcess`` folder.  If not, they will still be added to the ``Unfiled`` folder.
 
-For example, using the sample files in the ``devops/wsi_deid`` folder, ``girder.local.example.allowall.conf`` is a configuration that changes the default folder and image column names, doesn't enforce naming constraints, and has some other UI options changed from the default.  The ``importManifestSchema.example.allowall.json`` file uses a very lax schema to not require an input file name.  The columns that are present have fairly minimal requirements.
+For example, using the following sample files in the ``devops/wsi_deid`` folder:
+
+* `girder.local.example.allowall.conf <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/devops/wsi_deid/girder.local.example.allowall.conf>`_ is a configuration that changes the default folder and image column names, doesn't enforce naming constraints, and has some other UI options changed from the default.
+* `importManifestSchema.example.allowall.json <https://github.com/DigitalSlideArchive/DSA-WSI-DeID/blob/master/devops/wsi_deid/importManifestSchema.example.allowall.json>`_ is a very lax schema that does not require an input file name.  The columns that are present have fairly minimal requirements.
 
 A ``docker-compose.local.yml`` could then be specified such as::
 


### PR DESCRIPTION
This PR is exploring ways to improve the customization docs by making it easier to make a link between the documented settings and the configuration files. Some ideas include

### Using the `include` directive to render the configuration files in the docs
This would allow users to see the entire configuration files in the customization documentation, while keeping up to date as future development changes the default/example configuration files. This would require using something like github pages to build documentation, since github doesn't appear to [support](https://github.com/github/markup/issues/172) using `include` with `literal`.

### Adding codeblocks to show example configuration
See commit d9ab995 for an example. This has the advantage of showing relevant configuration code near its explanation in the documentation, but adds a burden if there are changes to the way these settings are defined in the future. Developers would have to come back to the docs and update the relevant sections if they, say, change how PHI/PII types are represented in the settings. Perhaps this is unlikely.

### Adding links to config files in github with line numbers
This avoids the bloat of adding entire config files or code blocks for each setting, but may be the most volatile, as new settings get added or the placement of settings with the config files changes.

**UPDATE 6/13/23**
Now, example have been added to sections that describe uses of settings defined in `girder.local.conf`. Some minor typos have also been fixed. Hyperlinks have been added for relevant files.