### PR TITLE
Retry tests a limited number of times on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run:
           name: Run server tests
           no_output_timeout: 15m
-          command: tox
+          command: PYTEST_ADDOPTS=--reruns=3 tox
       - run:
           name: Run web tests
           command: |

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
 skip_missing_interpreters = true
 
 [testenv]
+passenv = PYTEST_*
 deps =
   coverage
   pooch
@@ -13,6 +14,7 @@ deps =
   pytest-mock
   pytest-cov
   pytest-girder
+  pytest-rerunfailures
   pytest-xdist
 install_command = pip install --find-links https://girder.github.io/large_image_wheels {opts} {packages}
 allowlist_externals =


### PR DESCRIPTION
Recently, we've seen transient failures on CI.  This should make those less noisy.