### PR TITLE
Hide upload button when in a SEER project folder

### DIFF
--- a/wsi_deid/web_client/tests/wsi_deidDefaultSchemaSpec.js
+++ b/wsi_deid/web_client/tests/wsi_deidDefaultSchemaSpec.js
@@ -51,6 +51,9 @@ describe('Test WSI DeID plugin with default schema', function () {
             waitsFor(function () {
                 return $('.wsi_deid-import-button').length;
             }, 'import button to appear');
+            waitsFor(function () {
+                return $('.g-upload-here-button').first().css('display') === 'none';
+            }, 'upload button to disappear');
         });
         it('clicks the import button', function () {
             runs(function () {

--- a/wsi_deid/web_client/views/HierarchyWidget.js
+++ b/wsi_deid/web_client/views/HierarchyWidget.js
@@ -386,6 +386,10 @@ wrap(HierarchyWidget, 'render', function (render) {
             error: null
         }).done((resp) => {
             if (resp) {
+                // Hide the upload button for WSI DEID folders. Users should be utilizing the
+                // `import` functionality instead of girder's `upload`.
+                const uploadButton = this.$el.find('.g-upload-here-button');
+                uploadButton.hide();
                 restRequest({
                     url: `wsi_deid/settings`,
                     error: null


### PR DESCRIPTION
Fix #351

Users should be adding images via the `import` button. The upload button is hidden post render of the hierarchy widget, as other SEER-specific controls are added.