### PR TITLE
Preserve checked items on re-render

### DIFF
--- a/wsi_deid/web_client/views/ItemList.js
+++ b/wsi_deid/web_client/views/ItemList.js
@@ -177,7 +177,6 @@ wrap(ItemListWidget, 'render', function (render) {
 
     /* Largely taken from girder/web_client/src/views/widgets/ItemListWidget.js
      */
-    this.checked = [];
     // If we set a selected item in the beginning we will center the selection while loading
     if (this._selectedItem && this._highlightItem) {
         this.scrollPositionObserver();
@@ -227,6 +226,14 @@ wrap(ItemListWidget, 'render', function (render) {
     };
     this.delegateEvents();
     this.listenTo(this, 'g:checkboxesChanged', updateChecked);
+    const itemCheckboxes = this.$el.find('.g-list-checkbox');
+    itemCheckboxes.each((index, checkbox) => {
+        const cid = $(checkbox).attr('g-item-cid');
+        if (this.checked.includes(cid)) {
+            $(checkbox).attr('checked', true);
+        }
+    });
+    this.trigger('g:checkboxesChanged');
     return this;
 });
 


### PR DESCRIPTION
Fix #342 

Since the SEER item view renders twice in project folders, there is an opportunity for users to check items in the item list, and then have those checked items be un-checked by re-render. This can cause problems with some workflow buttons, or leave the "check all" checkbox checked erroneously. 

Now, instead of clearing the list of checked CIDs, we re-check those elements and trigger an event to update the workflow controls accordingly.