### PR TITLE
Guard against slow subtree counts.

### DIFF
--- a/wsi_deid/web_client/views/HierarchyWidget.js
+++ b/wsi_deid/web_client/views/HierarchyWidget.js
@@ -449,8 +449,12 @@ wrap(HierarchyWidget, 'fetchAndShowChildCount', function (fetchAndShowChildCount
     const reshowSubtreeCounts = () => {
         restRequest({
             url: `wsi_deid/resource/${this.parentModel.id}/subtreeCount`,
-            data: { type: this.parentModel.get('_modelType') }
+            data: { type: this.parentModel.get('_modelType') },
+            error: null
         }).done((data) => {
+            if (!data || data.folders === undefined) {
+                return;
+            }
             this.parentModel.set('nSubtreeCount', data);
             showSubtreeCounts();
         });


### PR DESCRIPTION
In some instances, this could completely bog down a server.