### PR TITLE
Add some frontend tests for lookup workflow

### DIFF
--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -89,6 +89,8 @@ def _provisionDefaultSchemaServer(tmp_path):
     # os.makedirs(unfiledPath, exist_ok=True)
     Setting().set(PluginSettings.WSI_DEID_IMPORT_PATH, str(importPath))
     Setting().set(PluginSettings.WSI_DEID_EXPORT_PATH, str(exportPath))
+    Setting().set(PluginSettings.WSI_DEID_DB_API_KEY, 'api-key')
+    Setting().set(PluginSettings.WSI_DEID_DB_API_URL, 'http://localhost:8080/matching/wsi')
     # Setting().set(PluginSettings.WSI_DEID_UNFILED_FOLDER, str(unfiledPath))
     for filename in {
         'SEER_Mouse_1_17158539.svs',

--- a/wsi_deid/web_client/tests/wsi_deidDefaultSchemaSpec.js
+++ b/wsi_deid/web_client/tests/wsi_deidDefaultSchemaSpec.js
@@ -77,8 +77,35 @@ describe('Test WSI DeID plugin with default schema', function () {
             waitsFor(function () {
                 return $('.g-refile-button').length;
             }, 'refile button to appear');
+            waitsFor(function () {
+                return $('.g-matching-button').length;
+            }, 'Database lookup button to appear');
         });
-        it('refiles the image', function () {
+        it('clicks the lookup button to open the dialog', function () {
+            runs(function () {
+                $('.g-matching-button').eq(0).click();
+            });
+            girderTest.waitForDialog();
+            runs(function () {
+                expect($('h3.modal-title').text()).toBe('Database Lookup');
+            });
+            expect($('.token-label-id').length).toEqual(0);
+        });
+        it('makes an API call', function () {
+            runs(function () {
+                $('.h-lookup').eq(0).click();
+            });
+            waitsFor(function () {
+                return $('.token-id-label').length;
+            }, 'The results table to appear');
+        });
+        it('closes the lookup dialog', function () {
+            $('#g-dialog-container').girderModal('close');
+            waitsFor(function () {
+                return $('body.modal-open').length === 0;
+            }, 'The lookup dialog to be closed');
+        });
+        it('refiles the image manually', function () {
             runs(function () {
                 var tokenInput = $('input.g-refile-tokenid').first();
                 tokenInput.val(tokenId);


### PR DESCRIPTION
This PR tests some behaviors of the frontend with respect to the API lookup workflow. It adds a simple end-to-end test, but doesn't actually set up the fake matching endpoint, and only really covers the case where the endpoint returns no results.

