### PR TITLE
added ability to configure the size of the macro square

### DIFF
--- a/wsi_deid/config.py
+++ b/wsi_deid/config.py
@@ -8,6 +8,8 @@ NUMERIC_VALUES = (
 
 defaultConfig = {
     'redact_macro_square': False,
+    'redact_macro_width_percent': 0,
+    'redact_macro_height_percent': 0,
     'always_redact_label': False,
     'require_redact_category': True,
     'require_reject_reason': False,

--- a/wsi_deid/process.py
+++ b/wsi_deid/process.py
@@ -1,7 +1,6 @@
 import base64
 import copy
 import io
-import logging
 import math
 import os
 import re
@@ -30,21 +29,6 @@ from .constants import PluginSettings, TokenOnlyPrefix
 
 OCRLock = threading.Lock()
 OCRReader = None
-
-logger = logging.getLogger('matching_api')
-logger.setLevel(logging.DEBUG)
-logger.addHandler(logging.StreamHandler())
-
-# Create a file handler and set its path to /tmp/matching_api.log
-file_handler = logging.FileHandler('/tmp/matching_api.log')
-file_handler.setLevel(logging.DEBUG)
-
-# Create a formatter
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-file_handler.setFormatter(formatter)
-
-# Add the file handler to the logger
-logger.addHandler(file_handler)
 
 def get_reader():
     global OCRReader


### PR DESCRIPTION
These configuration settings allow you to set the width and height of the box that gets redacted for the image macro.  This feature is useful, because not all slides have the same overhang.  The overhang on the slides at YSM are smaller than the default, so the current redaction square was cutting off some of the slide.  The configuration properties are under the [wsi_deid] heading:

- redact_macro_width_percent = 0
- redact_macro_height_percent = 0 

We use the default (current) setting, unless both the width and height percentages are set to a value greater than 0.  A configuration looks something like this:

**[wsi_deid]**
redact_macro_square = True
redact_macro_width_percent = 18
redact_macro_height_percent = 100
....

