### PR TITLE
Fix OCR batch jobs from import

### DIFF
--- a/wsi_deid/jobs.py
+++ b/wsi_deid/jobs.py
@@ -81,7 +81,7 @@ def start_ocr_batch_job(job):
             status=JobStatus.ERROR,
         )
         return
-    itemIds = job_args[0]
+    itemIds = job_args
     try:
         for itemId in itemIds:
             get_label_text_for_item(itemId, job)


### PR DESCRIPTION
Fix a case where a batch job from an import (like S3) would fail to run OCR