### PR TITLE
Update trivyignore.

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -17,7 +17,5 @@ CVE-2026-23949
 CVE-2026-24049
 # HIGH: python-pkg - pillow: Pillow: Out-of-bounds Write via Specially Crafted
 CVE-2026-25990
-# CRITICAL: ubuntu - kernel: nvmet-tcp: add bounds checks in nvmet_tcp_build_pd
-CVE-2026-23112
-# HIGH: ubuntu - kernel: kernel: Privilege escalation or denial of service via
-CVE-2026-23231
+# HIGH: python-pkg - FITS GZIP decompression bomb in Pillow
+CVE-2026-40192


### PR DESCRIPTION
The older python provided for iSyntax support needs to ignore a warning; that code isn't even accessible on the primary code path